### PR TITLE
feat: align theme tokens with design system

### DIFF
--- a/src/components/AIXUSDemo.tsx
+++ b/src/components/AIXUSDemo.tsx
@@ -42,55 +42,55 @@ export default function AIXUSDemo() {
   };
 
   return (
-    <div className="space-y-12">
+    <div className="space-y-12 text-foreground">
       {/* Clinician dashboard */}
       <section>
-        <h2 className="text-2xl font-semibold mb-4">Clinician Dashboard</h2>
+        <h2 className="text-heading-sm font-semibold mb-4">Clinician Dashboard</h2>
         <div className="flex flex-wrap gap-4 justify-center">
           {/* Hannah card */}
-          <div className="bg-secondary rounded-lg p-4 w-72 shadow-md">
-            <h3 className="font-semibold text-lg">Hannah Young</h3>
-            <p className="text-sm text-gray-400 mb-1">Appendectomy</p>
+          <div className="bg-surface rounded-lg p-4 w-72 shadow-md border border-border">
+            <h3 className="font-semibold text-heading-xs">Hannah Young</h3>
+            <p className="text-body-sm text-neutral-400 mb-1">Appendectomy</p>
             <div className="text-4xl font-bold mb-2">70</div>
-            <p className="text-sm text-yellow-400">Missing Informed Consent</p>
-            <p className="text-sm text-yellow-400">Anti-coagulant missing</p>
-            <div className="h-2 bg-darkbg rounded mt-2 mb-1 overflow-hidden">
+            <p className="text-body-sm text-warning">Missing Informed Consent</p>
+            <p className="text-body-sm text-warning">Anti-coagulant missing</p>
+            <div className="h-2 bg-surface-muted rounded mt-2 mb-1 overflow-hidden">
               <div className="h-full bg-accent" style={{ width: '85%' }}></div>
             </div>
             <p className="text-sm">85% of tasks completed</p>
           </div>
           {/* George card */}
-          <div className="bg-secondary rounded-lg p-4 w-72 shadow-md">
-            <h3 className="font-semibold text-lg">George Mallory</h3>
-            <p className="text-sm text-gray-400 mb-1">Inguinal Hernia Repair</p>
+          <div className="bg-surface rounded-lg p-4 w-72 shadow-md border border-border">
+            <h3 className="font-semibold text-heading-xs">George Mallory</h3>
+            <p className="text-body-sm text-neutral-400 mb-1">Inguinal Hernia Repair</p>
             <div className="text-4xl font-bold mb-2">93</div>
-            <p className="text-sm text-green-400">All tasks completed</p>
-            <div className="h-2 bg-darkbg rounded mt-2 mb-1 overflow-hidden">
-              <div className="h-full bg-green-400 w-full"></div>
+            <p className="text-body-sm text-success">All tasks completed</p>
+            <div className="h-2 bg-surface-muted rounded mt-2 mb-1 overflow-hidden">
+              <div className="h-full bg-success w-full"></div>
             </div>
             <p className="text-sm">100% of tasks completed</p>
           </div>
         </div>
-        <div className="bg-secondary rounded-lg p-4 mt-6 shadow-md max-w-xl mx-auto">
-          <h3 className="font-semibold text-lg mb-3">Hannah’s Outcome Concerns</h3>
+        <div className="bg-surface rounded-lg p-4 mt-6 shadow-md max-w-xl mx-auto border border-border">
+          <h3 className="font-semibold text-heading-xs mb-3">Hannah’s Outcome Concerns</h3>
           <div className="w-full h-64">
             <ResponsiveContainer width="100%" height="100%">
               <RadarChart data={radarData} outerRadius="80%">
-                <PolarGrid stroke="#143d6c" />
+                <PolarGrid stroke="var(--color-border)" />
                 <PolarAngleAxis
                   dataKey="subject"
-                  tick={{ fill: '#eef2f7', fontSize: 12 }}
+                  tick={{ fill: 'var(--color-muted)', fontSize: 12 }}
                 />
                 <PolarRadiusAxis
                   angle={30}
                   domain={[0, 10]}
-                  tick={{ fill: '#eef2f7', fontSize: 10 }}
+                  tick={{ fill: 'var(--color-muted)', fontSize: 10 }}
                 />
                 <Radar
                   name="Hannah"
                   dataKey="A"
-                  stroke="#81a7ef"
-                  fill="#81a7ef"
+                  stroke="var(--color-accent)"
+                  fill="var(--color-accent)"
                   fillOpacity={0.4}
                 />
               </RadarChart>
@@ -100,12 +100,12 @@ export default function AIXUSDemo() {
       </section>
       {/* Patient tasks */}
       <section>
-        <h2 className="text-2xl font-semibold mb-4">Patient Tasks</h2>
-        <div className="bg-secondary rounded-lg p-4 mx-auto max-w-sm text-center shadow-md">
+        <h2 className="text-heading-sm font-semibold mb-4">Patient Tasks</h2>
+        <div className="bg-surface rounded-lg p-4 mx-auto max-w-sm text-center shadow-md border border-border">
           <h3 className="font-semibold mb-1">Readiness Score</h3>
           <div className="text-5xl font-bold mb-2">87</div>
-          <p className="text-sm text-gray-400">You're well prepared for surgery</p>
-          <ul className="mt-4 space-y-2 text-sm">
+          <p className="text-body-sm text-neutral-400">You're well prepared for surgery</p>
+          <ul className="mt-4 space-y-2 text-body-sm text-muted">
             <li className="flex justify-between"><span>Oct 15</span><span>Eat 85 g protein</span></li>
             <li className="flex justify-between"><span>Oct 15</span><span>Chlorhexidine bath</span></li>
             <li className="flex justify-between"><span>Oct 16</span><span>Stop anti-coagulant</span></li>
@@ -114,8 +114,8 @@ export default function AIXUSDemo() {
       </section>
       {/* Modern informed consent */}
       <section>
-        <h2 className="text-2xl font-semibold mb-4">Modern Informed Consent</h2>
-        <div className="bg-secondary rounded-lg p-4 mx-auto max-w-md shadow-md">
+        <h2 className="text-heading-sm font-semibold mb-4">Modern Informed Consent</h2>
+        <div className="bg-surface rounded-lg p-4 mx-auto max-w-md shadow-md border border-border">
           <p className="mb-3">
             Welcome Hannah,<br />Dr. Grey has prepared this informed consent process for you.
           </p>
@@ -135,7 +135,7 @@ export default function AIXUSDemo() {
                 ref={(el) => (inputRefs.current[idx] = el)}
                 onChange={(e) => handleOtpChange(idx, e.target.value)}
                 onKeyDown={(e) => handleOtpKeyDown(idx, e)}
-                className="w-10 h-10 text-center text-lg rounded-md border border-primary bg-darkbg focus:outline-none text-white"
+                className="w-10 h-10 text-center text-lg rounded-md border border-border bg-surface focus:outline-none focus:ring-2 focus:ring-primary/40 text-foreground"
               />
             ))}
           </div>
@@ -143,8 +143,8 @@ export default function AIXUSDemo() {
       </section>
       {/* Recovery time */}
       <section>
-        <h2 className="text-2xl font-semibold mb-4">Recovery Time</h2>
-        <div className="bg-secondary rounded-lg p-4 mx-auto max-w-md text-center shadow-md">
+        <h2 className="text-heading-sm font-semibold mb-4">Recovery Time</h2>
+        <div className="bg-surface rounded-lg p-4 mx-auto max-w-md text-center shadow-md border border-border">
           <p className="mb-4">
             Based on what you have heard so far adjust the slider to the number of days you expect to be back at work.
           </p>
@@ -154,10 +154,10 @@ export default function AIXUSDemo() {
             max={14}
             value={recoveryDays}
             onChange={(e) => setRecoveryDays(Number(e.target.value))}
-            className="w-full accent-accent mb-2"
+            className="w-full accent-primary mb-2"
           />
           <div className="mb-2">Selected: {recoveryDays} days</div>
-          <button className="px-4 py-2 rounded-md bg-primary text-white font-semibold hover:bg-primary/90">
+          <button className="px-4 py-2 rounded-md bg-primary text-primary-contrast font-semibold transition-colors hover:bg-primary-strong">
             Submit
           </button>
         </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -22,29 +22,29 @@ export default function Layout({ children }: LayoutProps) {
   };
 
   return (
-    <div className="min-h-screen flex flex-col text-gray-900 transition-colors dark:text-gray-100">
-      <header className="sticky top-0 z-50 border-b border-slate-200/70 bg-white/80 backdrop-blur transition-colors dark:border-white/10 dark:bg-darkbg/80">
+    <div className="min-h-screen flex flex-col bg-background text-foreground transition-colors">
+      <header className="sticky top-0 z-50 border-b border-border bg-surface backdrop-blur transition-colors">
         <nav className="mx-auto flex w-full max-w-6xl items-center justify-between gap-6 px-6 py-4">
           <Link href="/" className="text-xl font-semibold text-primary">
             AIXUS Health
           </Link>
-          <div className="flex items-center gap-6 text-sm font-medium">
-            <Link href="/" className="text-gray-700 transition-colors hover:text-primary dark:text-gray-200">
+          <div className="flex items-center gap-6 text-sm font-medium text-muted">
+            <Link href="/" className="transition-colors hover:text-primary">
               Home
             </Link>
-            <Link href="/demo" className="text-gray-700 transition-colors hover:text-primary dark:text-gray-200">
+            <Link href="/demo" className="transition-colors hover:text-primary">
               Demo
             </Link>
-            <Link href="/plan" className="text-gray-700 transition-colors hover:text-primary dark:text-gray-200">
+            <Link href="/plan" className="transition-colors hover:text-primary">
               Plan
             </Link>
-            <Link href="/stack" className="text-gray-700 transition-colors hover:text-primary dark:text-gray-200">
+            <Link href="/stack" className="transition-colors hover:text-primary">
               Stack
             </Link>
             <button
               type="button"
               onClick={handleToggleTheme}
-              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 bg-white text-gray-900 shadow-sm transition-colors hover:bg-slate-100 dark:border-white/10 dark:bg-darkbg dark:text-gray-100 dark:hover:bg-darkbg2"
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border bg-surface text-foreground shadow-sm transition-colors hover:bg-background-subtle"
               aria-label="Toggle theme"
             >
               {mounted ? (
@@ -63,14 +63,14 @@ export default function Layout({ children }: LayoutProps) {
       <main className="flex-1">
         {children}
       </main>
-      <footer className="border-t border-slate-200/70 bg-white/80 transition-colors dark:border-white/10 dark:bg-darkbg/80">
-        <div className="mx-auto flex w-full max-w-6xl flex-col items-center justify-between gap-4 px-6 py-6 text-sm text-gray-600 transition-colors dark:text-gray-300 sm:flex-row">
+      <footer className="border-t border-border bg-surface transition-colors">
+        <div className="mx-auto flex w-full max-w-6xl flex-col items-center justify-between gap-4 px-6 py-6 text-body-sm text-muted transition-colors sm:flex-row">
           <p>&copy; {new Date().getFullYear()} AIXUS Health. All rights reserved.</p>
           <div className="flex gap-4">
-            <Link href="/plan" className="transition-colors hover:text-primary dark:hover:text-primary">
+            <Link href="/plan" className="transition-colors hover:text-primary">
               Action Plan
             </Link>
-            <Link href="/stack" className="transition-colors hover:text-primary dark:hover:text-primary">
+            <Link href="/stack" className="transition-colors hover:text-primary">
               Tech Stack
             </Link>
           </div>

--- a/src/pages/demo.tsx
+++ b/src/pages/demo.tsx
@@ -3,13 +3,13 @@ import AIXUSDemo from '@/components/AIXUSDemo';
 
 export default function DemoPage() {
   return (
-    <main className="min-h-screen p-6 space-y-8">
+    <main className="min-h-screen bg-background text-foreground p-6 space-y-8">
       <header className="text-center space-y-2">
-        <h1 className="text-3xl sm:text-4xl font-bold">AIXUS Interactive Demo</h1>
-        <p className="text-gray-300 max-w-3xl mx-auto">
+        <h1 className="text-heading-md sm:text-heading-lg font-bold">AIXUS Interactive Demo</h1>
+        <p className="text-muted text-body-md max-w-3xl mx-auto">
           Walk through the core experiences: clinician dashboard, patient tasks, informed consent and recovery planning.
         </p>
-        <Link href="/" className="inline-block mt-2 px-4 py-2 rounded-md border border-primary text-accent font-semibold hover:bg-secondary transition-colors">
+        <Link href="/" className="inline-block mt-2 px-4 py-2 rounded-md border border-border bg-background text-foreground font-semibold transition-colors hover:border-primary hover:text-primary hover:bg-background-subtle">
           Back to Home
         </Link>
       </header>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -4,9 +4,9 @@ import { motion } from 'framer-motion';
 
 export default function Home() {
   return (
-    <main className="min-h-screen flex flex-col items-center justify-center text-center p-6">
+    <main className="min-h-screen flex flex-col items-center justify-center bg-background text-center text-foreground p-6">
       <motion.h1
-        className="text-4xl sm:text-5xl font-bold mb-4 leading-tight"
+        className="text-heading-lg sm:text-heading-xl font-bold mb-4 leading-tight"
         initial={{ opacity: 0, y: -20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.6 }}
@@ -16,7 +16,7 @@ export default function Home() {
         by individualizing the care pathway
       </motion.h1>
       <motion.p
-        className="max-w-xl mx-auto text-lg text-gray-300 mb-8"
+        className="max-w-xl mx-auto text-body-lg text-muted mb-8"
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
         transition={{ duration: 0.6, delay: 0.1 }}
@@ -32,19 +32,19 @@ export default function Home() {
       >
         <Link
           href="/demo"
-          className="px-6 py-3 rounded-md bg-primary text-white font-semibold hover:bg-primary/90 transition-colors"
+          className="px-6 py-3 rounded-md bg-primary text-primary-contrast font-semibold shadow-sm transition-colors hover:bg-primary-strong"
         >
           Explore Demo
         </Link>
         <Link
           href="/plan"
-          className="px-6 py-3 rounded-md border border-primary text-accent font-semibold hover:bg-secondary hover:border-secondary transition-colors"
+          className="px-6 py-3 rounded-md border border-border bg-background text-foreground font-semibold transition-colors hover:border-primary hover:text-primary hover:bg-background-subtle"
         >
           View Action Plan
         </Link>
         <Link
           href="/stack"
-          className="px-6 py-3 rounded-md border border-primary text-accent font-semibold hover:bg-secondary hover:border-secondary transition-colors"
+          className="px-6 py-3 rounded-md border border-border bg-background text-foreground font-semibold transition-colors hover:border-primary hover:text-primary hover:bg-background-subtle"
         >
           Tech Stack
         </Link>

--- a/src/pages/plan.tsx
+++ b/src/pages/plan.tsx
@@ -92,14 +92,14 @@ export default function PlanPage() {
   };
 
   return (
-    <main className="min-h-screen p-6">
+    <main className="min-h-screen bg-background text-foreground p-6">
       <header className="text-center mb-6 space-y-2">
-        <h1 className="text-3xl sm:text-4xl font-bold">Action Plan Board</h1>
-        <p className="text-gray-300 max-w-3xl mx-auto">
+        <h1 className="text-heading-md sm:text-heading-lg font-bold">Action Plan Board</h1>
+        <p className="text-muted text-body-md max-w-3xl mx-auto">
           Organise tasks by priority and track progress. Drag tasks between the Now, Next and Later columns,
           filter by owner, or export your plan as JSON.
         </p>
-        <Link href="/" className="inline-block px-4 py-2 rounded-md border border-primary text-accent font-semibold hover:bg-secondary transition-colors">
+        <Link href="/" className="inline-block px-4 py-2 rounded-md border border-border bg-background text-foreground font-semibold transition-colors hover:border-primary hover:text-primary hover:bg-background-subtle">
           Back to Home
         </Link>
       </header>
@@ -108,17 +108,17 @@ export default function PlanPage() {
           value={filterOwner}
           onChange={(e) => setFilterOwner(e.target.value)}
           placeholder="Filter by owner (optional)"
-          className="flex-1 min-w-[12rem] px-3 py-2 rounded-md border border-secondary bg-darkbg text-sm focus:outline-none"
+          className="flex-1 min-w-[12rem] px-3 py-2 rounded-md border border-border bg-surface text-body-sm text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-primary/40"
         />
         <button
           onClick={() => setFilterOwner('')}
-          className="px-3 py-2 rounded-md bg-primary text-white font-semibold hover:bg-primary/90"
+          className="px-3 py-2 rounded-md bg-primary text-primary-contrast font-semibold transition-colors hover:bg-primary-strong"
         >
           Clear Filter
         </button>
         <button
           onClick={exportBoard}
-          className="px-3 py-2 rounded-md bg-primary text-white font-semibold hover:bg-primary/90"
+          className="px-3 py-2 rounded-md bg-primary text-primary-contrast font-semibold transition-colors hover:bg-primary-strong"
         >
           Export JSON
         </button>
@@ -129,11 +129,11 @@ export default function PlanPage() {
           return (
             <div
               key={status}
-              className="flex-1 min-w-[250px] bg-secondary rounded-lg p-4 shadow-md flex flex-col"
+              className="flex-1 min-w-[250px] bg-surface rounded-lg p-4 shadow-md flex flex-col border border-border"
               onDragOver={(e) => e.preventDefault()}
               onDrop={() => handleDrop(status)}
             >
-              <h2 className="text-xl font-semibold text-center mb-2 capitalize">{status}</h2>
+              <h2 className="text-heading-xs font-semibold text-center mb-2 capitalize">{status}</h2>
               <div className="flex-1 space-y-2 overflow-y-auto">
                 {tasks
                   .filter((t) =>
@@ -146,18 +146,18 @@ export default function PlanPage() {
                       key={task.id}
                       draggable
                       onDragStart={() => handleDragStart(task, status)}
-                      className="bg-darkbg p-2 rounded-md cursor-grab"
+                      className="bg-background-subtle p-2 rounded-md cursor-grab shadow-sm border border-border"
                     >
-                      <div className="font-semibold text-sm">{task.title}</div>
+                      <div className="font-semibold text-body-sm text-foreground">{task.title}</div>
                       {task.owner && (
-                        <div className="text-xs text-gray-400">{task.owner}</div>
+                        <div className="text-xs text-neutral-400">{task.owner}</div>
                       )}
                     </div>
                   ))}
               </div>
               <button
                 onClick={() => addTask(status)}
-                className="mt-2 px-3 py-1 rounded-md bg-darkbg text-accent text-sm hover:bg-darkbg/80"
+                className="mt-2 px-3 py-1 rounded-md bg-primary-soft text-primary-strong text-body-sm font-semibold transition-colors hover:bg-primary"
               >
                 + Add Task
               </button>

--- a/src/pages/stack.tsx
+++ b/src/pages/stack.tsx
@@ -79,10 +79,10 @@ export default function TechStack() {
       initial={{ opacity: 0, y: 30 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.5 }}
-      className="max-w-3xl mx-auto p-6 text-left"
+      className="max-w-3xl mx-auto bg-background text-foreground p-6 text-left"
     >
-      <h1 className="text-3xl font-bold mb-4">Our Technology Stack</h1>
-      <p className="mb-6 text-lg text-gray-300">
+      <h1 className="text-heading-md font-bold mb-4">Our Technology Stack</h1>
+      <p className="mb-6 text-body-md text-muted">
         Explore the tools and technologies that power the AIXUS platform.
       </p>
       <div className="space-y-4">
@@ -95,10 +95,10 @@ export default function TechStack() {
               initial={{ opacity: 0, y: 10 }}
               animate={{ opacity: 1, y: 0 }}
               transition={{ duration: 0.3 }}
-              className="border border-primary/20 rounded-lg overflow-hidden"
+              className="border border-border rounded-lg overflow-hidden bg-surface shadow-sm"
             >
               <button
-                className="flex justify-between items-center w-full px-4 py-3 bg-secondary/20 hover:bg-secondary/30 transition-colors"
+                className="flex justify-between items-center w-full px-4 py-3 bg-surface-muted hover:bg-background-subtle transition-colors text-foreground"
                 onClick={() => toggleSection(index)}
               >
                 <span className="font-semibold">{section.title}</span>
@@ -115,12 +115,12 @@ export default function TechStack() {
                     animate={{ height: 'auto', opacity: 1 }}
                     exit={{ height: 0, opacity: 0 }}
                     transition={{ duration: 0.3 }}
-                    className="px-4 py-3 bg-secondary/10 space-y-2"
+                    className="px-4 py-3 bg-background-subtle space-y-2"
                   >
                     {section.items.map((item) => (
                       <div key={item.title}>
                         <h3 className="font-medium">{item.title}</h3>
-                        <p className="text-gray-300">{item.description}</p>
+                        <p className="text-muted">{item.description}</p>
                       </div>
                     ))}
                   </motion.div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,26 +2,182 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Custom global styles */
-html {
-  color-scheme: light;
+:root {
+  --font-heading: 'Plus Jakarta Sans', ui-sans-serif, system-ui, sans-serif;
+  --font-body: 'Inter', ui-sans-serif, system-ui, sans-serif;
+
+  --text-body: 1.0625rem;
+  --text-body-leading: 1.65;
+  --text-body-small: 0.9375rem;
+  --text-body-large: 1.1875rem;
+  --heading-1: 3.5rem;
+  --heading-1-leading: 1.1;
+  --heading-2: 2.5rem;
+  --heading-2-leading: 1.2;
+  --heading-3: 1.875rem;
+  --heading-3-leading: 1.3;
+  --heading-4: 1.5rem;
+  --heading-4-leading: 1.35;
+  --heading-5: 1.25rem;
+  --heading-5-leading: 1.4;
+
+  --color-background: #f8fafc;
+  --color-background-subtle: #eef2ff;
+  --color-background-elevated: #ffffff;
+  --color-foreground: #0f172a;
+  --color-muted: #475569;
+  --color-border: #c7d2fe;
+  --color-surface: #ffffff;
+  --color-surface-muted: #edf2ff;
+  --color-surface-strong: #0f172a;
+
+  --color-primary: #2563eb;
+  --color-primary-contrast: #f8fafc;
+  --color-primary-soft: #93c5fd;
+  --color-primary-strong: #1d4ed8;
+
+  --color-accent: #38bdf8;
+  --color-accent-contrast: #0f172a;
+  --color-accent-soft: #bae6fd;
+
+  --color-gradient-start: #1d4ed8;
+  --color-gradient-middle: #6366f1;
+  --color-gradient-end: #a855f7;
+
+  --color-success: #22c55e;
+  --color-success-soft: #bbf7d0;
+  --color-warning: #fbbf24;
+  --color-warning-soft: #fef3c7;
+
+  --neutral-50: #f8fafc;
+  --neutral-100: #f1f5f9;
+  --neutral-200: #e2e8f0;
+  --neutral-300: #cbd5f5;
+  --neutral-400: #94a3b8;
+  --neutral-500: #64748b;
+  --neutral-600: #475569;
+  --neutral-700: #334155;
+  --neutral-800: #1e293b;
+  --neutral-900: #0f172a;
 }
 
-body {
-  @apply bg-gray-50 text-gray-900;
-  font-family: 'Inter', sans-serif;
+html {
+  color-scheme: light;
+  background-color: var(--color-background);
 }
 
 html.dark {
   color-scheme: dark;
+  --color-background: #020617;
+  --color-background-subtle: #0f172a;
+  --color-background-elevated: #111c2f;
+  --color-foreground: #e2e8f0;
+  --color-muted: #94a3b8;
+  --color-border: #1e293b;
+  --color-surface: #0f172a;
+  --color-surface-muted: #14213d;
+  --color-surface-strong: #020b1b;
+  --color-primary: #60a5fa;
+  --color-primary-contrast: #0f172a;
+  --color-primary-soft: #1d4ed8;
+  --color-primary-strong: #1e40af;
+  --color-accent: #38bdf8;
+  --color-accent-contrast: #020617;
+  --color-accent-soft: #0ea5e9;
+  --color-gradient-start: #1d4ed8;
+  --color-gradient-middle: #7c3aed;
+  --color-gradient-end: #a855f7;
+  --color-success: #4ade80;
+  --color-success-soft: #14532d;
+  --color-warning: #facc15;
+  --color-warning-soft: #713f12;
+  --neutral-50: #0f172a;
+  --neutral-100: #111c2f;
+  --neutral-200: #14213d;
+  --neutral-300: #1e293b;
+  --neutral-400: #334155;
+  --neutral-500: #475569;
+  --neutral-600: #64748b;
+  --neutral-700: #cbd5f5;
+  --neutral-800: #e2e8f0;
+  --neutral-900: #f8fafc;
 }
 
-html.dark body {
-  @apply bg-gradient-to-br from-darkbg to-darkbg2 text-gray-100;
-}
+@layer base {
+  *,
+  *::before,
+  *::after {
+    border-color: var(--color-border);
+  }
 
-a {
-  @apply text-accent;
+  body {
+    background-color: var(--color-background);
+    color: var(--color-foreground);
+    font-family: var(--font-body);
+    font-size: var(--text-body);
+    line-height: var(--text-body-leading);
+    text-rendering: optimizeLegibility;
+  }
+
+  p {
+    font-size: var(--text-body);
+    line-height: var(--text-body-leading);
+    color: var(--color-muted);
+  }
+
+  small,
+  .text-sm {
+    font-size: var(--text-body-small);
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--font-heading);
+    color: var(--color-foreground);
+    font-weight: 700;
+    letter-spacing: -0.02em;
+  }
+
+  h1 {
+    font-size: var(--heading-1);
+    line-height: var(--heading-1-leading);
+  }
+
+  h2 {
+    font-size: var(--heading-2);
+    line-height: var(--heading-2-leading);
+  }
+
+  h3 {
+    font-size: var(--heading-3);
+    line-height: var(--heading-3-leading);
+  }
+
+  h4 {
+    font-size: var(--heading-4);
+    line-height: var(--heading-4-leading);
+  }
+
+  h5,
+  h6 {
+    font-size: var(--heading-5);
+    line-height: var(--heading-5-leading);
+  }
+
+  a {
+    color: var(--color-primary);
+    font-weight: 500;
+    text-decoration: none;
+  }
+
+  a:hover,
+  a:focus {
+    color: var(--color-primary-strong);
+  }
 }
 
 @keyframes fade-in {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,12 +7,70 @@ module.exports = {
   theme: {
     extend: {
       colors: {
-        primary: '#2769c7',
-        secondary: '#0e2546',
-        accent: '#81a7ef',
-        darkbg: '#021d38',
-        darkbg2: '#052c58',
+        background: {
+          DEFAULT: 'var(--color-background)',
+          subtle: 'var(--color-background-subtle)',
+          elevated: 'var(--color-background-elevated)'
+        },
+        foreground: 'var(--color-foreground)',
+        muted: 'var(--color-muted)',
+        border: 'var(--color-border)',
+        surface: {
+          DEFAULT: 'var(--color-surface)',
+          muted: 'var(--color-surface-muted)',
+          strong: 'var(--color-surface-strong)'
+        },
+        primary: {
+          DEFAULT: 'var(--color-primary)',
+          contrast: 'var(--color-primary-contrast)',
+          soft: 'var(--color-primary-soft)',
+          strong: 'var(--color-primary-strong)'
+        },
+        accent: {
+          DEFAULT: 'var(--color-accent)',
+          contrast: 'var(--color-accent-contrast)',
+          soft: 'var(--color-accent-soft)'
+        },
+        gradient: {
+          start: 'var(--color-gradient-start)',
+          middle: 'var(--color-gradient-middle)',
+          end: 'var(--color-gradient-end)'
+        },
+        neutral: {
+          50: 'var(--neutral-50)',
+          100: 'var(--neutral-100)',
+          200: 'var(--neutral-200)',
+          300: 'var(--neutral-300)',
+          400: 'var(--neutral-400)',
+          500: 'var(--neutral-500)',
+          600: 'var(--neutral-600)',
+          700: 'var(--neutral-700)',
+          800: 'var(--neutral-800)',
+          900: 'var(--neutral-900)'
+        },
+        success: {
+          DEFAULT: 'var(--color-success)',
+          soft: 'var(--color-success-soft)'
+        },
+        warning: {
+          DEFAULT: 'var(--color-warning)',
+          soft: 'var(--color-warning-soft)'
+        }
       },
+      fontFamily: {
+        heading: ['"Plus Jakarta Sans"', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        body: ['"Inter"', 'ui-sans-serif', 'system-ui', 'sans-serif']
+      },
+      fontSize: {
+        'body-sm': ['0.9375rem', { lineHeight: '1.5' }],
+        'body-md': ['1.0625rem', { lineHeight: '1.6' }],
+        'body-lg': ['1.1875rem', { lineHeight: '1.65' }],
+        'heading-xs': ['1.25rem', { lineHeight: '1.4', letterSpacing: '-0.01em' }],
+        'heading-sm': ['1.5rem', { lineHeight: '1.35', letterSpacing: '-0.015em' }],
+        'heading-md': ['1.875rem', { lineHeight: '1.3', letterSpacing: '-0.02em' }],
+        'heading-lg': ['2.5rem', { lineHeight: '1.2', letterSpacing: '-0.025em' }],
+        'heading-xl': ['3.5rem', { lineHeight: '1.1', letterSpacing: '-0.03em' }]
+      }
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- expand Tailwind theme with palette, neutral ramps, and typography tokens backed by CSS variables
- define global light and dark CSS variables and typography defaults that consume the new tokens
- replace hard-coded component colors with design token utilities across pages and layout components

## Testing
- npm run build *(fails: Cannot find module 'next-themes' type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a638713c8323a682d5d77a1137cc