### PR TITLE
Refresh homepage aesthetic and typography

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.next
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.env*
+.vercel

--- a/public/images/hero-app-1.svg
+++ b/public/images/hero-app-1.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="640" viewBox="0 0 320 640" fill="none">
+  <defs>
+    <linearGradient id="screenGradient1" x1="40" y1="64" x2="280" y2="576" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#9bd4ff" />
+      <stop offset="0.5" stop-color="#7c9bff" />
+      <stop offset="1" stop-color="#c4b7ff" />
+    </linearGradient>
+  </defs>
+  <rect x="24" y="20" width="272" height="600" rx="48" fill="#0f172a" opacity="0.8" />
+  <rect x="36" y="52" width="248" height="548" rx="32" fill="url(#screenGradient1)" />
+  <circle cx="160" cy="36" r="6" fill="#1f2937" />
+  <rect x="72" y="120" width="176" height="24" rx="12" fill="rgba(15, 23, 42, 0.3)" />
+  <rect x="72" y="168" width="140" height="18" rx="9" fill="rgba(15, 23, 42, 0.18)" />
+  <rect x="72" y="220" width="176" height="120" rx="24" fill="rgba(248, 250, 252, 0.6)" />
+  <rect x="72" y="364" width="104" height="18" rx="9" fill="rgba(15, 23, 42, 0.18)" />
+  <rect x="72" y="404" width="176" height="18" rx="9" fill="rgba(15, 23, 42, 0.18)" />
+  <rect x="72" y="444" width="176" height="18" rx="9" fill="rgba(15, 23, 42, 0.18)" />
+  <rect x="72" y="484" width="176" height="18" rx="9" fill="rgba(15, 23, 42, 0.18)" />
+</svg>

--- a/public/images/hero-app-2.svg
+++ b/public/images/hero-app-2.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="600" viewBox="0 0 300 600" fill="none">
+  <defs>
+    <linearGradient id="screenGradient2" x1="30" y1="40" x2="260" y2="560" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#c7f1ff" />
+      <stop offset="0.6" stop-color="#98b5ff" />
+      <stop offset="1" stop-color="#d6b6ff" />
+    </linearGradient>
+  </defs>
+  <rect x="20" y="16" width="260" height="568" rx="44" fill="#111c2f" opacity="0.88" />
+  <rect x="32" y="52" width="236" height="516" rx="28" fill="url(#screenGradient2)" />
+  <circle cx="150" cy="32" r="5" fill="#020617" />
+  <rect x="64" y="124" width="172" height="20" rx="10" fill="rgba(2, 6, 23, 0.2)" />
+  <rect x="64" y="160" width="120" height="16" rx="8" fill="rgba(2, 6, 23, 0.16)" />
+  <rect x="64" y="208" width="172" height="96" rx="20" fill="rgba(248, 250, 252, 0.55)" />
+  <rect x="64" y="332" width="152" height="16" rx="8" fill="rgba(2, 6, 23, 0.16)" />
+  <rect x="64" y="368" width="172" height="16" rx="8" fill="rgba(2, 6, 23, 0.16)" />
+  <rect x="64" y="404" width="132" height="16" rx="8" fill="rgba(2, 6, 23, 0.16)" />
+  <rect x="64" y="440" width="172" height="16" rx="8" fill="rgba(2, 6, 23, 0.16)" />
+  <rect x="108" y="500" width="84" height="44" rx="22" fill="#0f172a" opacity="0.35" />
+</svg>

--- a/public/patterns/grid.svg
+++ b/public/patterns/grid.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" fill="none">
+  <rect width="10" height="10" fill="rgba(255, 255, 255, 0)" />
+  <path d="M0 .5h10M0 5.5h10M0 9.5h10M.5 0v10M5.5 0v10M9.5 0v10" stroke="rgba(148, 163, 184, 0.2)" stroke-width="0.5" />
+  <circle cx="5" cy="5" r="0.5" fill="rgba(148, 163, 184, 0.25)" />
+</svg>

--- a/src/components/FeatureCard.tsx
+++ b/src/components/FeatureCard.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { LucideIcon } from 'lucide-react';
+import { motion } from 'framer-motion';
+
+interface FeatureCardProps {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  delay?: number;
+}
+
+export function FeatureCard({ icon: Icon, title, description, delay = 0 }: FeatureCardProps) {
+  return (
+    <motion.article
+      className="group rounded-2xl border border-border p-6 shadow-sm backdrop-blur-sm transition-transform duration-300 hover:-translate-y-1 hover:shadow-lg"
+      style={{ backgroundColor: 'var(--color-surface)' }}
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.4 }}
+      transition={{ duration: 0.6, delay }}
+    >
+      <div
+        className="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-full"
+        style={{ backgroundColor: 'rgba(95, 141, 255, 0.18)' }}
+      >
+        <Icon className="h-6 w-6 text-[color:var(--color-primary-soft)]" strokeWidth={1.5} />
+      </div>
+      <h3 className="text-heading-sm font-bold text-foreground mb-2">{title}</h3>
+      <p className="text-body-md text-muted">{description}</p>
+    </motion.article>
+  );
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,54 +1,239 @@
 "use client";
-import Link from 'next/link';
+import Image from 'next/image';
 import { motion } from 'framer-motion';
+import { CheckCircle2, ClipboardCheck, ShieldCheck, Sparkle, Stethoscope } from 'lucide-react';
+
+import { FeatureCard } from '@/components/FeatureCard';
+
+const features = [
+  {
+    icon: Sparkle,
+    title: 'Intelligent orchestration',
+    description:
+      'Automated outreach, reminders, and education dynamically adapt to each patient’s risk profile and progress.'
+  },
+  {
+    icon: ClipboardCheck,
+    title: 'Surgical readiness clarity',
+    description:
+      'Surface a live readiness score and actionable tasks so clinical teams can proactively remove barriers to surgery.'
+  },
+  {
+    icon: Stethoscope,
+    title: 'Clinician collaboration',
+    description:
+      'Unify perioperative teams with a shared workflow that aligns surgeons, nurses, and care navigators.'
+  },
+  {
+    icon: ShieldCheck,
+    title: 'Recovery confidence',
+    description:
+      'Deliver individualized recovery plans and symptom tracking that give patients peace of mind after discharge.'
+  }
+];
+
+const careJourney = [
+  {
+    title: 'Risk stratification',
+    description: 'AI flags pulmonary risk as moderate and schedules respiratory coaching.',
+    status: 'In Motion',
+    tone: 'accent'
+  },
+  {
+    title: 'Pre-op checklist',
+    description: 'Patient confirmed medication hold and completed fasting questionnaire.',
+    status: 'Completed',
+    tone: 'success'
+  },
+  {
+    title: 'Care navigator note',
+    description: 'Navigator escalated mobility concern to PT with same-day telehealth slot.',
+    status: 'Escalated',
+    tone: 'warning'
+  }
+];
 
 export default function Home() {
   return (
-    <main className="min-h-screen flex flex-col items-center justify-center bg-background text-center text-foreground p-6">
-      <motion.h1
-        className="text-heading-lg sm:text-heading-xl font-bold mb-4 leading-tight"
-        initial={{ opacity: 0, y: -20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.6 }}
-      >
-        AIXUS Health is redefining the clinical experience
-        <br />
-        by individualizing the care pathway
-      </motion.h1>
-      <motion.p
-        className="max-w-xl mx-auto text-body-lg text-muted mb-8"
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.6, delay: 0.1 }}
-      >
-        Empower clinicians and patients with real‑time insights. From pre‑op readiness to
-        recovery, the AIXUS platform keeps everyone aligned on tasks, expectations and outcomes.
-      </motion.p>
-      <motion.div
-        className="flex gap-4 flex-wrap justify-center"
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 0.6, delay: 0.2 }}
-      >
-        <Link
-          href="/demo"
-          className="px-6 py-3 rounded-md bg-primary text-primary-contrast font-semibold shadow-sm transition-colors hover:bg-primary-strong"
+    <section
+      className="relative min-h-screen overflow-hidden"
+      style={{
+        backgroundImage: "url('/patterns/grid.svg'), var(--color-background)",
+        backgroundSize: '10rem 10rem, cover',
+        backgroundRepeat: 'repeat, no-repeat'
+      }}
+    >
+      <div className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-white/30 via-transparent to-white/10 dark:from-[#0f172a]/40 dark:via-transparent dark:to-[#0f172a]/30" />
+      <main className="relative z-10 mx-auto flex w-full max-w-6xl flex-col gap-24 px-6 py-16 sm:py-24">
+        <motion.section
+          className="grid items-center gap-16 lg:grid-cols-[1.05fr_0.95fr]"
+          initial="hidden"
+          animate="visible"
+          variants={{ hidden: {}, visible: {} }}
         >
-          Explore Demo
-        </Link>
-        <Link
-          href="/plan"
-          className="px-6 py-3 rounded-md border border-border bg-background text-foreground font-semibold transition-colors hover:border-primary hover:text-primary hover:bg-background-subtle"
-        >
-          View Action Plan
-        </Link>
-        <Link
-          href="/stack"
-          className="px-6 py-3 rounded-md border border-border bg-background text-foreground font-semibold transition-colors hover:border-primary hover:text-primary hover:bg-background-subtle"
-        >
-          Tech Stack
-        </Link>
-      </motion.div>
-    </main>
+          <div className="space-y-10 text-left">
+            <motion.div
+              initial={{ opacity: 0, y: -24 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6 }}
+              className="space-y-6"
+            >
+              <span
+                className="inline-flex items-center rounded-full px-4 py-2 text-sm font-semibold text-primary"
+                style={{ backgroundColor: 'rgba(200, 236, 255, 0.55)' }}
+              >
+                AI X US platform
+              </span>
+              <h1 className="text-heading-lg sm:text-heading-xl font-bold text-foreground">
+                Let’s End One Size Fits All Healthcare
+              </h1>
+              <p className="max-w-xl text-body-lg text-muted">
+                AI X US is optimizing patient outcomes by personalizing the surgical journey. We illuminate the path from
+                preparation through recovery so every patient, clinician, and care team member is informed and empowered.
+              </p>
+            </motion.div>
+            <motion.div
+              className="rounded-3xl border border-border bg-surface/80 p-8 shadow-lg backdrop-blur-sm"
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: 0.15 }}
+            >
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="text-body-sm font-semibold uppercase tracking-[0.25em] text-muted">Product simulation</p>
+                  <h2 className="mt-2 text-heading-xs font-bold text-foreground">Navigator workspace</h2>
+                </div>
+                <span className="rounded-full bg-[color:var(--color-primary-soft)]/40 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
+                  Live preview
+                </span>
+              </div>
+              <ul className="mt-8 space-y-6">
+                {careJourney.map((item) => (
+                  <li key={item.title} className="flex items-start gap-4">
+                    <span
+                      className="mt-1 flex h-9 w-9 items-center justify-center rounded-full shadow-inner"
+                      style={{
+                        backgroundColor:
+                          item.tone === 'success'
+                            ? 'rgba(34, 197, 94, 0.18)'
+                            : item.tone === 'warning'
+                              ? 'rgba(251, 191, 36, 0.18)'
+                              : 'rgba(125, 216, 255, 0.22)',
+                        color:
+                          item.tone === 'success'
+                            ? 'var(--color-success)'
+                            : item.tone === 'warning'
+                              ? 'var(--color-warning)'
+                              : 'var(--color-accent)'
+                      }}
+                    >
+                      <CheckCircle2 className="h-5 w-5" strokeWidth={1.8} />
+                    </span>
+                    <div>
+                      <div className="flex flex-wrap items-baseline gap-3">
+                        <p className="text-body-md font-semibold text-foreground">{item.title}</p>
+                        <span
+                          className="rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide"
+                          style={{
+                            backgroundColor:
+                              item.tone === 'success'
+                                ? 'rgba(34, 197, 94, 0.12)'
+                                : item.tone === 'warning'
+                                  ? 'rgba(251, 191, 36, 0.12)'
+                                  : 'rgba(125, 216, 255, 0.16)',
+                            color:
+                              item.tone === 'success'
+                                ? 'var(--color-success)'
+                                : item.tone === 'warning'
+                                  ? 'var(--color-warning)'
+                                  : 'var(--color-accent-contrast)'
+                          }}
+                        >
+                          {item.status}
+                        </span>
+                      </div>
+                      <p className="mt-2 text-body-sm text-muted">{item.description}</p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+              <div className="mt-8 flex items-center gap-3 text-sm text-muted">
+                <span className="inline-flex h-2 w-2 rounded-full bg-primary" />
+                <span>Updated moments ago from our synthetic pre-op cohort run.</span>
+              </div>
+            </motion.div>
+            <motion.dl
+              className="grid gap-6 sm:grid-cols-2"
+              initial={{ opacity: 0, y: 30 }}
+              animate={{ opacity: 1, y: 0 }}
+              transition={{ duration: 0.6, delay: 0.25 }}
+            >
+              <div
+                className="rounded-2xl border border-border p-6 backdrop-blur"
+                style={{ backgroundColor: 'var(--color-surface)' }}
+              >
+                <dt className="text-body-sm uppercase tracking-[0.2em] text-muted">Surgical Readiness</dt>
+                <dd className="mt-2 flex items-baseline gap-3">
+                  <span className="text-5xl font-semibold text-[color:var(--color-score)]">92%</span>
+                  <span className="text-body-md text-muted">average readiness score</span>
+                </dd>
+              </div>
+              <div
+                className="rounded-2xl border border-border p-6 backdrop-blur"
+                style={{ backgroundColor: 'var(--color-surface)' }}
+              >
+                <dt className="text-body-sm uppercase tracking-[0.2em] text-muted">Task Completion</dt>
+                <dd className="mt-2 flex items-baseline gap-3">
+                  <span className="text-5xl font-semibold text-primary">48</span>
+                  <span className="text-body-md text-muted">critical tasks automated weekly</span>
+                </dd>
+              </div>
+            </motion.dl>
+          </div>
+          <motion.div
+            className="relative flex justify-center"
+            initial={{ opacity: 0, x: 40 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ duration: 0.7, delay: 0.2 }}
+          >
+            <div className="relative flex h-full w-full max-w-md flex-col items-center justify-center">
+              <div
+                className="absolute inset-0 -z-10 rounded-full blur-3xl"
+                style={{ backgroundColor: 'rgba(125, 216, 255, 0.45)' }}
+              />
+              <Image
+                src="/images/hero-app-1.svg"
+                alt="AIXUS mobile experience overview"
+                width={320}
+                height={640}
+                className="drop-shadow-2xl"
+              />
+              <Image
+                src="/images/hero-app-2.svg"
+                alt="Personalized care pathway on AIXUS"
+                width={300}
+                height={600}
+                className="-mt-24 w-[65%] -translate-x-12 drop-shadow-2xl sm:-translate-x-16"
+              />
+            </div>
+          </motion.div>
+        </motion.section>
+
+        <section className="space-y-12">
+          <div className="max-w-2xl">
+            <h2 className="text-heading-md font-bold text-foreground">Care teams move faster with clarity.</h2>
+            <p className="mt-4 text-body-lg text-muted">
+              Clinicians, navigators, and patients gain a single shared operating picture. These experience pillars deliver the
+              confidence and calm needed to navigate the surgical journey without surprises.
+            </p>
+          </div>
+          <div className="grid gap-8 md:grid-cols-2">
+            {features.map((feature, index) => (
+              <FeatureCard key={feature.title} {...feature} delay={0.1 * index} />
+            ))}
+          </div>
+        </section>
+      </main>
+    </section>
   );
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -6,43 +6,54 @@
   --font-heading: 'Plus Jakarta Sans', ui-sans-serif, system-ui, sans-serif;
   --font-body: 'Inter', ui-sans-serif, system-ui, sans-serif;
 
-  --text-body: 1.0625rem;
+  --text-body: 1.125rem;
   --text-body-leading: 1.65;
   --text-body-small: 0.9375rem;
-  --text-body-large: 1.1875rem;
-  --heading-1: 3.5rem;
-  --heading-1-leading: 1.1;
+  --text-body-large: 1.25rem;
+  --heading-1: 4.25rem;
+  --heading-1-leading: 1.05;
   --heading-2: 2.5rem;
   --heading-2-leading: 1.2;
-  --heading-3: 1.875rem;
-  --heading-3-leading: 1.3;
+  --heading-3: 2rem;
+  --heading-3-leading: 1.25;
   --heading-4: 1.5rem;
   --heading-4-leading: 1.35;
   --heading-5: 1.25rem;
   --heading-5-leading: 1.4;
 
-  --color-background: #f8fafc;
-  --color-background-subtle: #eef2ff;
-  --color-background-elevated: #ffffff;
+  --color-background: linear-gradient(
+    135deg,
+    var(--color-gradient-start),
+    var(--color-gradient-middle),
+    var(--color-gradient-end)
+  );
+  --color-background-subtle: linear-gradient(
+    160deg,
+    rgba(236, 252, 255, 0.8),
+    rgba(238, 242, 255, 0.65)
+  );
+  --color-background-elevated: rgba(255, 255, 255, 0.85);
   --color-foreground: #0f172a;
   --color-muted: #475569;
-  --color-border: #c7d2fe;
-  --color-surface: #ffffff;
-  --color-surface-muted: #edf2ff;
+  --color-border: rgba(148, 163, 184, 0.35);
+  --color-surface: rgba(255, 255, 255, 0.9);
+  --color-surface-muted: rgba(236, 252, 255, 0.6);
   --color-surface-strong: #0f172a;
 
-  --color-primary: #2563eb;
+  --color-primary: #5f8dff;
   --color-primary-contrast: #f8fafc;
-  --color-primary-soft: #93c5fd;
-  --color-primary-strong: #1d4ed8;
+  --color-primary-soft: #b9d3ff;
+  --color-primary-strong: #3f6ee6;
 
-  --color-accent: #38bdf8;
+  --color-accent: #7dd8ff;
   --color-accent-contrast: #0f172a;
-  --color-accent-soft: #bae6fd;
+  --color-accent-soft: #c8ecff;
 
   --color-gradient-start: #1d4ed8;
   --color-gradient-middle: #6366f1;
   --color-gradient-end: #a855f7;
+
+  --color-score: #facc15;
 
   --color-success: #22c55e;
   --color-success-soft: #bbf7d0;
@@ -68,29 +79,39 @@ html {
 
 html.dark {
   color-scheme: dark;
-  --color-background: #020617;
-  --color-background-subtle: #0f172a;
-  --color-background-elevated: #111c2f;
+  --color-background: linear-gradient(
+    140deg,
+    var(--color-gradient-start),
+    var(--color-gradient-middle),
+    var(--color-gradient-end)
+  );
+  --color-background-subtle: linear-gradient(
+    160deg,
+    rgba(15, 23, 42, 0.95),
+    rgba(49, 46, 129, 0.85)
+  );
+  --color-background-elevated: rgba(15, 23, 42, 0.85);
   --color-foreground: #e2e8f0;
   --color-muted: #94a3b8;
   --color-border: #1e293b;
   --color-surface: #0f172a;
-  --color-surface-muted: #14213d;
+  --color-surface-muted: rgba(30, 41, 59, 0.75);
   --color-surface-strong: #020b1b;
-  --color-primary: #60a5fa;
-  --color-primary-contrast: #0f172a;
-  --color-primary-soft: #1d4ed8;
-  --color-primary-strong: #1e40af;
-  --color-accent: #38bdf8;
+  --color-primary: #7aa9ff;
+  --color-primary-contrast: #020617;
+  --color-primary-soft: #4055d4;
+  --color-primary-strong: #2c3ca8;
+  --color-accent: #58c8ff;
   --color-accent-contrast: #020617;
-  --color-accent-soft: #0ea5e9;
-  --color-gradient-start: #1d4ed8;
-  --color-gradient-middle: #7c3aed;
-  --color-gradient-end: #a855f7;
+  --color-accent-soft: #2563eb;
+  --color-gradient-start: #0f172a;
+  --color-gradient-middle: #312e81;
+  --color-gradient-end: #5b21b6;
   --color-success: #4ade80;
   --color-success-soft: #14532d;
   --color-warning: #facc15;
   --color-warning-soft: #713f12;
+  --color-score: #fde047;
   --neutral-50: #0f172a;
   --neutral-100: #111c2f;
   --neutral-200: #14213d;
@@ -111,7 +132,11 @@ html.dark {
   }
 
   body {
-    background-color: var(--color-background);
+    background-color: var(--neutral-50);
+    background-image: url('/patterns/grid.svg'), var(--color-background);
+    background-size: 10rem 10rem, cover;
+    background-repeat: repeat, no-repeat;
+    background-attachment: fixed;
     color: var(--color-foreground);
     font-family: var(--font-body);
     font-size: var(--text-body);
@@ -139,7 +164,7 @@ html.dark {
     font-family: var(--font-heading);
     color: var(--color-foreground);
     font-weight: 700;
-    letter-spacing: -0.02em;
+    letter-spacing: -0.015em;
   }
 
   h1 {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -63,13 +63,13 @@ module.exports = {
       },
       fontSize: {
         'body-sm': ['0.9375rem', { lineHeight: '1.5' }],
-        'body-md': ['1.0625rem', { lineHeight: '1.6' }],
-        'body-lg': ['1.1875rem', { lineHeight: '1.65' }],
-        'heading-xs': ['1.25rem', { lineHeight: '1.4', letterSpacing: '-0.01em' }],
-        'heading-sm': ['1.5rem', { lineHeight: '1.35', letterSpacing: '-0.015em' }],
-        'heading-md': ['1.875rem', { lineHeight: '1.3', letterSpacing: '-0.02em' }],
-        'heading-lg': ['2.5rem', { lineHeight: '1.2', letterSpacing: '-0.025em' }],
-        'heading-xl': ['3.5rem', { lineHeight: '1.1', letterSpacing: '-0.03em' }]
+        'body-md': ['1.125rem', { lineHeight: '1.65' }],
+        'body-lg': ['1.25rem', { lineHeight: '1.7' }],
+        'heading-xs': ['1.25rem', { lineHeight: '1.35', letterSpacing: '-0.008em' }],
+        'heading-sm': ['1.5rem', { lineHeight: '1.3', letterSpacing: '-0.012em' }],
+        'heading-md': ['2rem', { lineHeight: '1.25', letterSpacing: '-0.015em' }],
+        'heading-lg': ['2.75rem', { lineHeight: '1.18', letterSpacing: '-0.02em' }],
+        'heading-xl': ['4.25rem', { lineHeight: '1.05', letterSpacing: '-0.015em' }]
       }
     },
   },


### PR DESCRIPTION
## Summary
- restyle the global color system with gradient backgrounds, softer primary/accent tones, and a subtle grid overlay
- increase heading/body typography scales and introduce a reusable feature card component with light lucide icons
- rebuild the home hero with new messaging, responsive app mockups, a navigator workspace simulation panel, and supporting feature grid imagery

## Testing
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5bac6a5308323b817469efb3790a8