### PR TITLE
Create codex-driven interactive story experience

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "aixus-next",
       "version": "1.0.0",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "autoprefixer": "10.4.16",
         "framer-motion": "12.23.22",
         "lucide-react": "0.272.0",
@@ -44,6 +47,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "start": "next start"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "autoprefixer": "10.4.16",
     "framer-motion": "12.23.22",
     "lucide-react": "0.272.0",

--- a/src/components/AIXUSDemo.tsx
+++ b/src/components/AIXUSDemo.tsx
@@ -1,167 +1,126 @@
 "use client";
 
-import { useState, useRef } from 'react';
-import {
-  RadarChart,
-  PolarGrid,
-  PolarAngleAxis,
-  PolarRadiusAxis,
-  Radar,
-  ResponsiveContainer,
-} from 'recharts';
+import { useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { ArrowRight, Compass, MapPin } from 'lucide-react';
+
+import { demoScenarios } from '@/data/codex';
+import { DemoScenarioTabs } from './DemoScenarioTabs';
 
 export default function AIXUSDemo() {
-  // Recovery slider state
-  const [recoveryDays, setRecoveryDays] = useState(7);
-  // OTP input state
-  const [otp, setOtp] = useState<string[]>(Array(6).fill(''));
-  const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+  const [activeScenarioId, setActiveScenarioId] = useState(demoScenarios[0]?.id ?? '');
 
-  // Radar chart data
-  const radarData = [
-    { subject: 'Recovery Time', A: 7, fullMark: 10 },
-    { subject: 'Pain', A: 5, fullMark: 10 },
-    { subject: 'Hospital Stay', A: 6, fullMark: 10 },
-    { subject: 'Physical Activity', A: 4, fullMark: 10 },
-  ];
+  const activeScenario = useMemo(
+    () => demoScenarios.find((scenario) => scenario.id === activeScenarioId) ?? demoScenarios[0],
+    [activeScenarioId],
+  );
 
-  const handleOtpChange = (index: number, value: string) => {
-    if (!/^[0-9]?$/.test(value)) return;
-    const newOtp = [...otp];
-    newOtp[index] = value;
-    setOtp(newOtp);
-    if (value && index < otp.length - 1) {
-      inputRefs.current[index + 1]?.focus();
-    }
-  };
-
-  const handleOtpKeyDown = (index: number, e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Backspace' && !otp[index] && index > 0) {
-      inputRefs.current[index - 1]?.focus();
-    }
-  };
+  const progressValue = useMemo(() => {
+    const index = demoScenarios.findIndex((scenario) => scenario.id === activeScenario?.id);
+    if (index === -1) return 0;
+    return ((index + 1) / demoScenarios.length) * 100;
+  }, [activeScenario?.id]);
 
   return (
-    <div className="space-y-12 text-foreground">
-      {/* Clinician dashboard */}
-      <section>
-        <h2 className="text-heading-sm font-semibold mb-4">Clinician Dashboard</h2>
-        <div className="flex flex-wrap gap-4 justify-center">
-          {/* Hannah card */}
-          <div className="bg-surface rounded-lg p-4 w-72 shadow-md border border-border">
-            <h3 className="font-semibold text-heading-xs">Hannah Young</h3>
-            <p className="text-body-sm text-neutral-400 mb-1">Appendectomy</p>
-            <div className="text-4xl font-bold mb-2">70</div>
-            <p className="text-body-sm text-warning">Missing Informed Consent</p>
-            <p className="text-body-sm text-warning">Anti-coagulant missing</p>
-            <div className="h-2 bg-surface-muted rounded mt-2 mb-1 overflow-hidden">
-              <div className="h-full bg-accent" style={{ width: '85%' }}></div>
-            </div>
-            <p className="text-sm">85% of tasks completed</p>
-          </div>
-          {/* George card */}
-          <div className="bg-surface rounded-lg p-4 w-72 shadow-md border border-border">
-            <h3 className="font-semibold text-heading-xs">George Mallory</h3>
-            <p className="text-body-sm text-neutral-400 mb-1">Inguinal Hernia Repair</p>
-            <div className="text-4xl font-bold mb-2">93</div>
-            <p className="text-body-sm text-success">All tasks completed</p>
-            <div className="h-2 bg-surface-muted rounded mt-2 mb-1 overflow-hidden">
-              <div className="h-full bg-success w-full"></div>
-            </div>
-            <p className="text-sm">100% of tasks completed</p>
-          </div>
-        </div>
-        <div className="bg-surface rounded-lg p-4 mt-6 shadow-md max-w-xl mx-auto border border-border">
-          <h3 className="font-semibold text-heading-xs mb-3">Hannah’s Outcome Concerns</h3>
-          <div className="w-full h-64">
-            <ResponsiveContainer width="100%" height="100%">
-              <RadarChart data={radarData} outerRadius="80%">
-                <PolarGrid stroke="var(--color-border)" />
-                <PolarAngleAxis
-                  dataKey="subject"
-                  tick={{ fill: 'var(--color-muted)', fontSize: 12 }}
-                />
-                <PolarRadiusAxis
-                  angle={30}
-                  domain={[0, 10]}
-                  tick={{ fill: 'var(--color-muted)', fontSize: 10 }}
-                />
-                <Radar
-                  name="Hannah"
-                  dataKey="A"
-                  stroke="var(--color-accent)"
-                  fill="var(--color-accent)"
-                  fillOpacity={0.4}
-                />
-              </RadarChart>
-            </ResponsiveContainer>
-          </div>
-        </div>
-      </section>
-      {/* Patient tasks */}
-      <section>
-        <h2 className="text-heading-sm font-semibold mb-4">Patient Tasks</h2>
-        <div className="bg-surface rounded-lg p-4 mx-auto max-w-sm text-center shadow-md border border-border">
-          <h3 className="font-semibold mb-1">Readiness Score</h3>
-          <div className="text-5xl font-bold mb-2">87</div>
-          <p className="text-body-sm text-neutral-400">You're well prepared for surgery</p>
-          <ul className="mt-4 space-y-2 text-body-sm text-muted">
-            <li className="flex justify-between"><span>Oct 15</span><span>Eat 85 g protein</span></li>
-            <li className="flex justify-between"><span>Oct 15</span><span>Chlorhexidine bath</span></li>
-            <li className="flex justify-between"><span>Oct 16</span><span>Stop anti-coagulant</span></li>
-          </ul>
-        </div>
-      </section>
-      {/* Modern informed consent */}
-      <section>
-        <h2 className="text-heading-sm font-semibold mb-4">Modern Informed Consent</h2>
-        <div className="bg-surface rounded-lg p-4 mx-auto max-w-md shadow-md border border-border">
-          <p className="mb-3">
-            Welcome Hannah,<br />Dr. Grey has prepared this informed consent process for you.
+    <section className="relative space-y-8 rounded-3xl border border-border/50 bg-gradient-to-b from-background-subtle/60 via-background/40 to-background/70 p-6 shadow-2xl sm:p-10">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <p className="inline-flex items-center gap-2 rounded-full border border-primary/40 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-primary">
+            Immersive demo
           </p>
-          <p className="mb-3">
-            While you are learning about your appendectomy we will be collecting some data to make sure you are
-            prepared for your surgery.
+          <h2 className="mt-4 text-heading-md font-semibold text-foreground sm:text-heading-lg">
+            Explore the orchestrated care workspace
+          </h2>
+          <p className="mt-2 max-w-2xl text-body-md text-muted">
+            Toggle between clinician, patient, and recovery journeys to watch the navigator workspace adapt in real time. Every persona pulls from the same Codex so storytelling stays in sync.
           </p>
-          <p className="mb-4">Please enter the six-digit code sent to your email to continue:</p>
-          <div className="flex gap-2 justify-center">
-            {otp.map((digit, idx) => (
-              <input
-                key={idx}
-                type="text"
-                inputMode="numeric"
-                maxLength={1}
-                value={digit}
-                ref={(el) => (inputRefs.current[idx] = el)}
-                onChange={(e) => handleOtpChange(idx, e.target.value)}
-                onKeyDown={(e) => handleOtpKeyDown(idx, e)}
-                className="w-10 h-10 text-center text-lg rounded-md border border-border bg-surface focus:outline-none focus:ring-2 focus:ring-primary/40 text-foreground"
+        </div>
+        <div className="flex items-center gap-3 text-xs uppercase tracking-[0.4em] text-muted">
+          <Compass className="h-4 w-4" /> Guided walkthrough
+        </div>
+      </header>
+
+      <div className="grid gap-8 lg:grid-cols-[0.4fr_1.6fr]">
+        <aside className="space-y-6 rounded-3xl border border-border/50 bg-surface/70 p-6 shadow-lg backdrop-blur">
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-muted">Scenario path</p>
+            <div className="relative h-2 rounded-full bg-border/40">
+              <motion.div
+                className="absolute inset-y-0 left-0 rounded-full bg-primary"
+                animate={{ width: `${progressValue}%` }}
+                transition={{ duration: 0.6, ease: 'easeInOut' }}
               />
-            ))}
+            </div>
+            <p className="text-sm text-muted">{Math.round(progressValue)}% through the story</p>
+          </div>
+
+          <nav className="space-y-4">
+            {demoScenarios.map((scenario, index) => {
+              const isActive = scenario.id === activeScenario?.id;
+              return (
+                <button
+                  key={scenario.id}
+                  type="button"
+                  onClick={() => setActiveScenarioId(scenario.id)}
+                  className={`group relative flex w-full items-center gap-4 rounded-2xl border px-4 py-3 text-left transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 ${isActive ? 'border-primary/50 bg-primary/10 text-foreground shadow-lg' : 'border-border/60 bg-background-subtle text-muted hover:text-foreground'}`}
+                >
+                  <span className="flex h-10 w-10 items-center justify-center rounded-full border border-border/50 bg-background">
+                    {index + 1}
+                  </span>
+                  <div>
+                    <p className="text-sm font-semibold uppercase tracking-[0.3em]">{scenario.label}</p>
+                    <p className="text-xs text-muted">{scenario.persona}</p>
+                  </div>
+                  <motion.span
+                    initial={false}
+                    animate={{ opacity: isActive ? 1 : 0, x: isActive ? 0 : -6 }}
+                    className="ml-auto text-primary"
+                  >
+                    <ArrowRight className="h-5 w-5" />
+                  </motion.span>
+                </button>
+              );
+            })}
+          </nav>
+
+          <div className="rounded-2xl border border-accent/30 bg-accent/10 p-4 text-sm text-accent">
+            <p className="font-semibold uppercase tracking-[0.4em]">Codex aligned</p>
+            <p className="mt-2 text-accent/80">
+              Active scenario data flows directly from the codex module. Update it once and the hero, demo, plan, and stack pages stay coordinated.
+            </p>
+          </div>
+        </aside>
+
+        <div className="space-y-6">
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={activeScenario?.id}
+              initial={{ opacity: 0, y: 24 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -24 }}
+              transition={{ duration: 0.45 }}
+            >
+              <DemoScenarioTabs
+                scenarios={demoScenarios}
+                activeScenarioId={activeScenarioId}
+                onScenarioChange={setActiveScenarioId}
+              />
+            </motion.div>
+          </AnimatePresence>
+
+          <div className="flex flex-wrap items-center justify-between gap-4 rounded-2xl border border-border/60 bg-background-subtle/80 p-5 text-sm text-muted">
+            <div className="flex items-center gap-3">
+              <MapPin className="h-4 w-4" />
+              <span>
+                Persona anchors from the Codex power navigation breadcrumbs and ensure layout sections highlight the right focus areas.
+              </span>
+            </div>
+            <span className="rounded-full border border-border/60 px-3 py-1 text-xs uppercase tracking-[0.4em]">
+              Codex synced
+            </span>
           </div>
         </div>
-      </section>
-      {/* Recovery time */}
-      <section>
-        <h2 className="text-heading-sm font-semibold mb-4">Recovery Time</h2>
-        <div className="bg-surface rounded-lg p-4 mx-auto max-w-md text-center shadow-md border border-border">
-          <p className="mb-4">
-            Based on what you have heard so far adjust the slider to the number of days you expect to be back at work.
-          </p>
-          <input
-            type="range"
-            min={1}
-            max={14}
-            value={recoveryDays}
-            onChange={(e) => setRecoveryDays(Number(e.target.value))}
-            className="w-full accent-primary mb-2"
-          />
-          <div className="mb-2">Selected: {recoveryDays} days</div>
-          <button className="px-4 py-2 rounded-md bg-primary text-primary-contrast font-semibold transition-colors hover:bg-primary-strong">
-            Submit
-          </button>
-        </div>
-      </section>
-    </div>
+      </div>
+    </section>
   );
 }

--- a/src/components/DemoScenarioTabs.tsx
+++ b/src/components/DemoScenarioTabs.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import { useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { CheckCircle2, Circle, Sparkles } from 'lucide-react';
+import {
+  Area,
+  AreaChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import { DemoScenario } from '@/data/codex';
+import { MetricCallouts, MetricCallout } from './MetricCallouts';
+
+interface DemoScenarioTabsProps {
+  scenarios: DemoScenario[];
+  activeScenarioId: string;
+  onScenarioChange: (scenarioId: string) => void;
+}
+
+const timelineTone: Record<DemoScenario['timeline'][number]['status'], string> = {
+  complete: 'bg-emerald-500/60 border-emerald-500/60 text-emerald-100',
+  active: 'bg-primary/40 border-primary/60 text-primary',
+  upcoming: 'bg-border/40 border-border/60 text-muted',
+};
+
+function toMetricCallouts(metrics: DemoScenario['metrics']): MetricCallout[] {
+  return metrics.map((metric) => ({
+    label: metric.label,
+    value: metric.value,
+    delta: metric.delta,
+    tone: metric.tone,
+  }));
+}
+
+export function DemoScenarioTabs({ scenarios, activeScenarioId, onScenarioChange }: DemoScenarioTabsProps) {
+  const [checklistState, setChecklistState] = useState<Record<string, Record<string, boolean>>>(() => {
+    return scenarios.reduce((acc, scenario) => {
+      acc[scenario.id] = scenario.checklist.reduce((column, item) => {
+        column[item.id] = item.complete;
+        return column;
+      }, {} as Record<string, boolean>);
+      return acc;
+    }, {} as Record<string, Record<string, boolean>>);
+  });
+
+  const activeScenario = useMemo(() => {
+    return scenarios.find((scenario) => scenario.id === activeScenarioId) ?? scenarios[0];
+  }, [scenarios, activeScenarioId]);
+
+  const handleChecklistToggle = (scenarioId: string, itemId: string) => {
+    setChecklistState((prev) => ({
+      ...prev,
+      [scenarioId]: {
+        ...prev[scenarioId],
+        [itemId]: !prev[scenarioId]?.[itemId],
+      },
+    }));
+  };
+
+  return (
+    <section className="space-y-8">
+      <div className="flex flex-wrap items-center gap-3">
+        {scenarios.map((scenario) => {
+          const isActive = scenario.id === activeScenario.id;
+          return (
+            <button
+              key={scenario.id}
+              type="button"
+              onClick={() => onScenarioChange(scenario.id)}
+              className={`group relative overflow-hidden rounded-full border px-4 py-2 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 ${isActive ? 'border-primary/60 bg-primary/10 text-primary' : 'border-border/60 bg-background-subtle text-muted hover:text-foreground'}`}
+            >
+              <span className="flex items-center gap-2">
+                <Sparkles className={`h-4 w-4 transition-colors ${isActive ? 'text-primary' : 'text-muted'}`} />
+                {scenario.label}
+              </span>
+              {isActive && (
+                <motion.span
+                  layoutId="scenario-tab-indicator"
+                  className="absolute inset-x-2 bottom-1 h-0.5 rounded-full bg-primary"
+                />
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={activeScenario.id}
+          initial={{ opacity: 0, y: 32 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: -32 }}
+          transition={{ duration: 0.45 }}
+          className="grid gap-8 rounded-3xl border border-border/50 bg-surface/70 p-6 shadow-xl backdrop-blur lg:grid-cols-[1.15fr_0.85fr]"
+        >
+          <div className="space-y-6">
+            <header className="space-y-3">
+              <span className="inline-flex items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-primary">
+                {activeScenario.persona}
+              </span>
+              <h2 className="text-heading-sm font-semibold text-foreground sm:text-heading-md">
+                {activeScenario.headline}
+              </h2>
+              <p className="text-body-md text-muted">{activeScenario.description}</p>
+            </header>
+
+            <div className="grid gap-6 md:grid-cols-[1fr_0.65fr]">
+              <div className="space-y-4">
+                <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-muted">Timeline</h3>
+                <div className="relative pl-4">
+                  <div className="absolute left-[0.4rem] top-2 bottom-2 w-0.5 bg-border/60" aria-hidden />
+                  <ul className="space-y-5">
+                    {activeScenario.timeline.map((item, index) => {
+                      const progress = ((index + 1) / activeScenario.timeline.length) * 100;
+                      return (
+                        <li key={item.id} className="relative">
+                          <motion.span
+                            layout
+                            className={`absolute -left-4 flex h-6 w-6 items-center justify-center rounded-full border text-[0.65rem] font-semibold uppercase ${timelineTone[item.status]}`}
+                          >
+                            {item.time.replace(/[^0-9A-Za-z]/g, '').slice(0, 2)}
+                          </motion.span>
+                          <div className="rounded-2xl border border-border/60 bg-background-subtle/80 p-4 shadow-sm">
+                            <div className="flex items-center justify-between gap-4">
+                              <p className="text-body-md font-semibold text-foreground">{item.title}</p>
+                              <motion.div
+                                layout
+                                className="h-1 w-24 overflow-hidden rounded-full bg-border"
+                              >
+                                <motion.div
+                                  className="h-full bg-primary"
+                                  initial={{ width: `${item.status === 'complete' ? 100 : item.status === 'active' ? 65 : 15}%` }}
+                                  animate={{ width: `${progress}%` }}
+                                  transition={{ duration: 0.6, delay: index * 0.05 }}
+                                />
+                              </motion.div>
+                            </div>
+                            <p className="mt-2 text-sm text-muted">{item.detail}</p>
+                          </div>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-muted">Readiness Pulse</h3>
+                <div className="relative h-48 w-full overflow-hidden rounded-2xl border border-border/60 bg-background-subtle/80 p-3">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <AreaChart data={activeScenario.chart.data}>
+                      <defs>
+                        <linearGradient id={`scenarioGradient-${activeScenario.id}`} x1="0" y1="0" x2="0" y2="1">
+                          <stop offset="5%" stopColor="var(--color-primary)" stopOpacity={0.6} />
+                          <stop offset="95%" stopColor="var(--color-primary)" stopOpacity={0.05} />
+                        </linearGradient>
+                      </defs>
+                      <XAxis dataKey="step" hide padding={{ left: 20, right: 20 }} />
+                      <YAxis hide domain={[0, 100]} />
+                      <Tooltip
+                        cursor={{ stroke: 'var(--color-border)', strokeWidth: 1 }}
+                        contentStyle={{
+                          background: 'var(--color-surface)',
+                          borderRadius: '12px',
+                          border: '1px solid var(--color-border)',
+                          color: 'var(--color-foreground)',
+                        }}
+                      />
+                      <Area
+                        type="monotone"
+                        dataKey="score"
+                        stroke="var(--color-primary)"
+                        strokeWidth={2}
+                        fill={`url(#scenarioGradient-${activeScenario.id})`}
+                      />
+                    </AreaChart>
+                  </ResponsiveContainer>
+                  <div className="pointer-events-none absolute inset-x-3 bottom-3 flex items-center justify-between text-xs text-muted">
+                    <span>{activeScenario.chart.label}</span>
+                    <span>{activeScenario.chart.data[activeScenario.chart.data.length - 1]?.score ?? ''}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <MetricCallouts
+              metrics={toMetricCallouts(activeScenario.metrics)}
+              columns={3}
+              activeKey={activeScenario.id}
+            />
+          </div>
+
+          <div className="space-y-6">
+            <div className="rounded-2xl border border-border/60 bg-background-subtle/80 p-5 shadow-md">
+              <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-muted">Interactive Checklist</h3>
+              <ul className="mt-4 space-y-3">
+                {activeScenario.checklist.map((item) => {
+                  const checked = checklistState[activeScenario.id]?.[item.id] ?? item.complete;
+                  return (
+                    <li key={item.id}>
+                      <button
+                        type="button"
+                        onClick={() => handleChecklistToggle(activeScenario.id, item.id)}
+                        className={`group flex w-full items-start gap-3 rounded-xl border border-border/60 bg-surface/80 p-3 text-left transition-colors hover:border-primary/40 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 ${checked ? 'shadow-lg' : ''}`}
+                      >
+                        <motion.span
+                          animate={{ scale: checked ? 1 : 0.95 }}
+                          className={`mt-1 rounded-full border p-1 ${checked ? 'border-emerald-400 bg-emerald-500/20 text-emerald-300' : 'border-border text-muted'}`}
+                        >
+                          {checked ? <CheckCircle2 className="h-4 w-4" /> : <Circle className="h-4 w-4" />}
+                        </motion.span>
+                        <div>
+                          <p className="text-sm font-medium text-foreground">{item.label}</p>
+                          {item.note && (
+                            <p className="text-xs text-muted">{item.note}</p>
+                          )}
+                        </div>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            </div>
+
+            <div className="rounded-2xl border border-primary/40 bg-primary/5 p-5 text-sm text-primary">
+              <p className="font-semibold uppercase tracking-[0.4em]">Scenario cadence</p>
+              <p className="mt-3 text-primary/80">
+                Switching personas updates the live chart, metrics, and checklist state so demos feel like a sequenced story.
+              </p>
+            </div>
+          </div>
+        </motion.div>
+      </AnimatePresence>
+    </section>
+  );
+}

--- a/src/components/HeroShowcase.tsx
+++ b/src/components/HeroShowcase.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import Image from 'next/image';
+import { AnimatePresence, motion } from 'framer-motion';
+import { HeroMetric, HeroSlide } from '@/data/codex';
+import { MetricCallouts } from './MetricCallouts';
+
+interface HeroShowcaseProps {
+  id?: string;
+  slides: HeroSlide[];
+  activeSlideId: string;
+  onSlideChange: (slideId: string) => void;
+}
+
+const slideVariants = {
+  initial: { opacity: 0, y: 24 },
+  animate: { opacity: 1, y: 0 },
+  exit: { opacity: 0, y: -24 },
+};
+
+function toMetricCallout(metric: HeroMetric) {
+  return {
+    label: metric.label,
+    value: metric.value,
+    description: metric.description,
+    trend: metric.trend,
+  };
+}
+
+export function HeroShowcase({ id, slides, activeSlideId, onSlideChange }: HeroShowcaseProps) {
+  const activeIndex = Math.max(
+    0,
+    slides.findIndex((slide) => slide.id === activeSlideId),
+  );
+  const activeSlide = slides[activeIndex] ?? slides[0];
+
+  return (
+    <section
+      id={id}
+      className="relative overflow-hidden rounded-3xl border border-border/40 bg-gradient-to-br from-surface via-surface/70 to-background-subtle p-6 sm:p-10 shadow-xl"
+    >
+      <div className="absolute inset-0 pointer-events-none" aria-hidden>
+        <div className="absolute -top-32 right-10 h-72 w-72 rounded-full bg-primary/10 blur-3xl" />
+        <div className="absolute bottom-0 left-10 h-48 w-48 rounded-full bg-accent/10 blur-3xl" />
+      </div>
+      <div className="relative grid gap-10 lg:grid-cols-[1.05fr_0.95fr]">
+        <div className="flex flex-col gap-8">
+          <div className="flex items-center justify-between gap-4">
+            <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+              {slides.map((slide, index) => {
+                const isActive = slide.id === activeSlide.id;
+                const progress = ((activeIndex + 1) / slides.length) * 100;
+                return (
+                  <button
+                    key={slide.id}
+                    type="button"
+                    onClick={() => onSlideChange(slide.id)}
+                    className={`relative rounded-full border px-4 py-2 text-sm font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 ${isActive ? 'border-primary/60 bg-primary/10 text-primary' : 'border-border/60 bg-background-subtle/60 text-muted hover:text-foreground'}`}
+                  >
+                    <span className="flex items-center gap-2">
+                      <span className="hidden text-xs uppercase tracking-[0.3em] text-muted sm:inline">{`0${index + 1}`}</span>
+                      {slide.subtitle}
+                    </span>
+                    {isActive && (
+                      <motion.span
+                        layoutId="hero-tab-indicator"
+                        className="absolute inset-x-1 bottom-1 h-0.5 rounded-full bg-primary/70"
+                        style={{ width: `${progress}%` }}
+                      />
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+            <div className="hidden sm:flex items-center gap-3 text-xs uppercase tracking-[0.4em] text-muted">
+              <span>Guided Story</span>
+              <motion.span
+                animate={{ opacity: [0.3, 1, 0.3] }}
+                transition={{ duration: 2.5, repeat: Infinity }}
+                className="inline-flex h-2 w-12 rounded-full bg-primary/40"
+              />
+            </div>
+          </div>
+
+          <div className="space-y-6">
+            <div className="flex items-center gap-2 text-xs uppercase tracking-[0.5em] text-primary/80">
+              <motion.span layoutId="hero-highlight-bullet" className="h-2 w-2 rounded-full bg-primary" />
+              {activeSlide.highlight}
+            </div>
+            <AnimatePresence mode="wait">
+              <motion.div
+                key={activeSlide.id}
+                variants={slideVariants}
+                initial="initial"
+                animate="animate"
+                exit="exit"
+                transition={{ duration: 0.45 }}
+                className="space-y-5"
+              >
+                <h1 className="text-heading-lg font-semibold text-foreground sm:text-heading-xl">
+                  {activeSlide.title}
+                </h1>
+                <p className="max-w-xl text-body-lg text-muted">{activeSlide.narrative}</p>
+              </motion.div>
+            </AnimatePresence>
+          </div>
+
+          <MetricCallouts
+            metrics={activeSlide.metrics.map(toMetricCallout)}
+            columns={2}
+            activeKey={activeSlide.id}
+          />
+        </div>
+
+        <div className="relative flex items-center justify-center">
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={activeSlide.media.src}
+              initial={{ opacity: 0, scale: 0.96, rotateX: -8 }}
+              animate={{ opacity: 1, scale: 1, rotateX: 0 }}
+              exit={{ opacity: 0, scale: 0.92, rotateX: 8 }}
+              transition={{ duration: 0.6 }}
+              className="relative w-full max-w-md overflow-hidden rounded-[2.5rem] border border-border/40 bg-gradient-to-b from-background-subtle/80 to-background/40 p-6 shadow-2xl"
+            >
+              <div className="absolute inset-0 bg-gradient-to-br from-primary/10 via-transparent to-accent/10 opacity-60" />
+              <div className="relative aspect-[10/16] w-full">
+                <Image
+                  src={activeSlide.media.src}
+                  alt={activeSlide.media.alt}
+                  fill
+                  priority
+                  className="object-cover object-center"
+                />
+              </div>
+              <div className="mt-6 flex items-center justify-between text-xs text-muted">
+                <span className="uppercase tracking-[0.4em]">{activeSlide.media.device}</span>
+                <span>{activeIndex + 1} / {slides.length}</span>
+              </div>
+            </motion.div>
+          </AnimatePresence>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,7 +1,8 @@
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import { useTheme } from 'next-themes';
-import { Moon, Sun } from 'lucide-react';
-import { useEffect, useState, type ReactNode } from 'react';
+import { Compass, Moon, Sun } from 'lucide-react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
 
 interface LayoutProps {
   children: ReactNode;
@@ -10,6 +11,52 @@ interface LayoutProps {
 export default function Layout({ children }: LayoutProps) {
   const { resolvedTheme, setTheme } = useTheme();
   const [mounted, setMounted] = useState(false);
+  const pathname = usePathname();
+
+  const navItems = useMemo(
+    () => [
+      {
+        label: 'Story',
+        href: '/#hero-story',
+        isActive: pathname === '/',
+      },
+      {
+        label: 'Navigator',
+        href: '/#navigator-experience',
+        isActive: pathname === '/',
+      },
+      {
+        label: 'Action Plan',
+        href: '/plan',
+        isActive: pathname === '/plan',
+      },
+      {
+        label: 'Tech Stack',
+        href: '/stack',
+        isActive: pathname === '/stack',
+      },
+    ],
+    [pathname],
+  );
+
+  const breadcrumbs = useMemo(() => {
+    if (pathname === '/plan') {
+      return [
+        { label: 'Codex', href: '/' },
+        { label: 'Action Plan', href: '/plan' },
+      ];
+    }
+    if (pathname === '/stack') {
+      return [
+        { label: 'Codex', href: '/' },
+        { label: 'Tech Stack', href: '/stack' },
+      ];
+    }
+    return [
+      { label: 'Codex', href: '/' },
+      { label: 'Storyline', href: '/#hero-story' },
+    ];
+  }, [pathname]);
 
   useEffect(() => {
     setMounted(true);
@@ -23,24 +70,26 @@ export default function Layout({ children }: LayoutProps) {
 
   return (
     <div className="min-h-screen flex flex-col bg-background text-foreground transition-colors">
-      <header className="sticky top-0 z-50 border-b border-border bg-surface backdrop-blur transition-colors">
+      <header className="sticky top-0 z-50 border-b border-border bg-surface/95 backdrop-blur transition-colors">
         <nav className="mx-auto flex w-full max-w-6xl items-center justify-between gap-6 px-6 py-4">
           <Link href="/" className="text-xl font-semibold text-primary">
             AIXUS Health
           </Link>
-          <div className="flex items-center gap-6 text-sm font-medium text-muted">
-            <Link href="/" className="transition-colors hover:text-primary">
-              Home
-            </Link>
-            <Link href="/demo" className="transition-colors hover:text-primary">
-              Demo
-            </Link>
-            <Link href="/plan" className="transition-colors hover:text-primary">
-              Plan
-            </Link>
-            <Link href="/stack" className="transition-colors hover:text-primary">
-              Stack
-            </Link>
+          <div className="flex items-center gap-4 text-sm font-medium text-muted">
+            {navItems.map((item) => (
+              <Link
+                key={item.label}
+                href={item.href}
+                className={`relative rounded-full border px-4 py-2 transition-colors hover:text-primary ${item.isActive ? 'border-primary/60 bg-primary/10 text-primary' : 'border-transparent'}`}
+                aria-current={item.isActive ? 'page' : undefined}
+                prefetch
+              >
+                {item.label}
+                {item.isActive && (
+                  <span className="absolute inset-x-4 bottom-1 h-0.5 rounded-full bg-primary/70" aria-hidden />
+                )}
+              </Link>
+            ))}
             <button
               type="button"
               onClick={handleToggleTheme}
@@ -59,6 +108,17 @@ export default function Layout({ children }: LayoutProps) {
             </button>
           </div>
         </nav>
+        <div className="mx-auto flex w-full max-w-6xl items-center gap-2 px-6 pb-3 text-xs font-semibold uppercase tracking-[0.4em] text-muted">
+          <Compass className="h-3.5 w-3.5" />
+          {breadcrumbs.map((crumb, index) => (
+            <span key={crumb.label} className="flex items-center gap-2">
+              {index > 0 && <span className="text-border">/</span>}
+              <Link href={crumb.href} className="hover:text-primary">
+                {crumb.label}
+              </Link>
+            </span>
+          ))}
+        </div>
       </header>
       <main className="flex-1">
         {children}

--- a/src/components/MetricCallouts.tsx
+++ b/src/components/MetricCallouts.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { AnimatePresence, motion } from 'framer-motion';
+import { useMemo } from 'react';
+
+type MetricTone = 'positive' | 'neutral' | 'warning';
+
+export interface MetricCallout {
+  label: string;
+  value: string;
+  description?: string;
+  delta?: string;
+  trend?: string;
+  tone?: MetricTone;
+}
+
+interface MetricCalloutsProps {
+  metrics: MetricCallout[];
+  columns?: 1 | 2 | 3;
+  activeKey?: string;
+}
+
+const toneClasses: Record<MetricTone, string> = {
+  positive: 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300',
+  neutral: 'border-sky-500/20 bg-sky-500/10 text-sky-200',
+  warning: 'border-amber-500/30 bg-amber-500/10 text-amber-200',
+};
+
+export function MetricCallouts({ metrics, columns = 3, activeKey }: MetricCalloutsProps) {
+  const gridClass = useMemo(() => {
+    if (columns === 1) return 'grid-cols-1';
+    if (columns === 2) return 'grid-cols-1 sm:grid-cols-2';
+    return 'grid-cols-1 sm:grid-cols-2 xl:grid-cols-3';
+  }, [columns]);
+
+  return (
+    <AnimatePresence mode="popLayout">
+      <motion.dl
+        key={activeKey || metrics.map((metric) => metric.label).join('-')}
+        initial={{ opacity: 0, y: 16 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -16 }}
+        transition={{ duration: 0.4 }}
+        className={`grid gap-4 ${gridClass}`}
+      >
+        {metrics.map((metric) => {
+          const tone = metric.tone ?? 'neutral';
+          return (
+            <motion.div
+              key={metric.label}
+              layout
+              whileHover={{ y: -4 }}
+              transition={{ type: 'spring', stiffness: 260, damping: 20 }}
+              className="group relative overflow-hidden rounded-2xl border border-border/60 bg-surface/70 p-5 shadow-lg backdrop-blur"
+            >
+              <div className="absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100" aria-hidden>
+                <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-primary/60 via-accent/60 to-primary/60" />
+              </div>
+              <dt className="text-xs font-semibold uppercase tracking-[0.25em] text-muted">
+                {metric.label}
+              </dt>
+              <dd className="mt-3 flex items-baseline gap-3">
+                <span className="text-4xl font-semibold text-foreground">{metric.value}</span>
+                {(metric.delta || metric.trend) && (
+                  <span
+                    className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[0.7rem] font-medium ${toneClasses[tone]}`}
+                  >
+                    {metric.delta ?? metric.trend}
+                  </span>
+                )}
+              </dd>
+              {metric.description && (
+                <p className="mt-2 text-sm text-muted">{metric.description}</p>
+              )}
+            </motion.div>
+          );
+        })}
+      </motion.dl>
+    </AnimatePresence>
+  );
+}

--- a/src/data/codex.ts
+++ b/src/data/codex.ts
@@ -1,0 +1,510 @@
+export interface HeroMetric {
+  label: string;
+  value: string;
+  description: string;
+  trend?: string;
+}
+
+export interface HeroSlide {
+  id: string;
+  title: string;
+  subtitle: string;
+  narrative: string;
+  highlight: string;
+  metrics: HeroMetric[];
+  media: {
+    device: 'mobile' | 'tablet' | 'desktop';
+    src: string;
+    alt: string;
+  };
+}
+
+export interface ScenarioTimelineItem {
+  id: string;
+  time: string;
+  title: string;
+  detail: string;
+  status: 'complete' | 'active' | 'upcoming';
+}
+
+export interface ScenarioChecklistItem {
+  id: string;
+  label: string;
+  complete: boolean;
+  note?: string;
+}
+
+export interface ScenarioMetric {
+  label: string;
+  value: string;
+  delta?: string;
+  tone?: 'positive' | 'neutral' | 'warning';
+}
+
+export interface DemoScenario {
+  id: string;
+  label: string;
+  persona: string;
+  headline: string;
+  description: string;
+  timeline: ScenarioTimelineItem[];
+  checklist: ScenarioChecklistItem[];
+  metrics: ScenarioMetric[];
+  chart: {
+    label: string;
+    data: { step: string; score: number }[];
+  };
+}
+
+export interface ActionPlanTask {
+  id: string;
+  title: string;
+  owner: string;
+  status: 'Planned' | 'In Flight' | 'Blocked' | 'Complete';
+  note?: string;
+}
+
+export interface ActionPlanColumn {
+  id: string;
+  title: string;
+  description: string;
+  focus: string;
+  tasks: ActionPlanTask[];
+}
+
+export interface TechStackItem {
+  name: string;
+  summary: string;
+  interaction: string;
+}
+
+export interface TechStackLayer {
+  id: 'frontend' | 'backend' | 'data' | 'infrastructure';
+  label: string;
+  description: string;
+  items: TechStackItem[];
+}
+
+export const heroSlides: HeroSlide[] = [
+  {
+    id: 'personalization',
+    title: 'Personalized surgical journeys start with clarity',
+    subtitle: 'Navigator workspace',
+    narrative:
+      'Surface readiness, outstanding tasks, and escalations in a single adaptive view. Clinicians receive proactive prompts while patients see next steps in plain language.',
+    highlight: 'Real-time orchestration engine',
+    metrics: [
+      {
+        label: 'Tasks automated',
+        value: '48',
+        description: 'per care coordinator each week',
+        trend: '+18% vs. last month',
+      },
+      {
+        label: 'Readiness lift',
+        value: '22%',
+        description: 'increase in on-time surgeries',
+      },
+    ],
+    media: {
+      device: 'tablet',
+      src: '/images/navigator-tablet.png',
+      alt: 'Tablet showing navigator workspace dashboard',
+    },
+  },
+  {
+    id: 'team-sync',
+    title: 'Keep surgeons, nurses, and navigators aligned',
+    subtitle: 'Team timeline',
+    narrative:
+      'AIXUS timelines show exactly where every perioperative task stands. Automated nudges reassign bottlenecks before they impact the surgical date.',
+    highlight: 'Escalation & collaboration fabric',
+    metrics: [
+      {
+        label: 'Cross-team updates',
+        value: '5.6x',
+        description: 'faster triage on escalations',
+        trend: '-2.3 hr cycle time',
+      },
+      {
+        label: 'Staff confidence',
+        value: '93',
+        description: 'experience score from pilot cohort',
+      },
+    ],
+    media: {
+      device: 'desktop',
+      src: '/images/team-desktop.png',
+      alt: 'Desktop UI showing team status timeline',
+    },
+  },
+  {
+    id: 'recovery',
+    title: 'Extend guidance into a confident recovery',
+    subtitle: 'Patient recovery coach',
+    narrative:
+      'Dynamic recovery plans adapt to patient-reported symptoms and wearable signals, closing the loop with surgeons through intelligent alerts.',
+    highlight: 'Recovery intelligence loop',
+    metrics: [
+      {
+        label: 'Symptom triage time',
+        value: '7 min',
+        description: 'average RN acknowledgement',
+      },
+      {
+        label: 'Patient alignment',
+        value: '87',
+        description: 'engagement score after discharge',
+        trend: '+9 vs. baseline',
+      },
+    ],
+    media: {
+      device: 'mobile',
+      src: '/images/recovery-mobile.png',
+      alt: 'Mobile phone showing recovery timeline controls',
+    },
+  },
+];
+
+export const demoScenarios: DemoScenario[] = [
+  {
+    id: 'clinician',
+    label: 'Clinician',
+    persona: 'Care Navigator',
+    headline: 'Hannah Young is nearly ready for surgery',
+    description:
+      'Clinical teams orchestrate readiness tasks and intervene quickly with AI-ranked risk signals.',
+    timeline: [
+      {
+        id: 'tl-1',
+        time: '08:40',
+        title: 'Respiratory coaching assigned',
+        detail: 'AI flagged pulmonary risk as moderate and created a targeted pre-op plan.',
+        status: 'complete',
+      },
+      {
+        id: 'tl-2',
+        time: '09:10',
+        title: 'Navigator escalated mobility concern',
+        detail: 'Physical therapy added to pathway with same-day telehealth slot.',
+        status: 'active',
+      },
+      {
+        id: 'tl-3',
+        time: '12:20',
+        title: 'Consent packet verification',
+        detail: 'Pending e-signature from patient; auto reminder scheduled.',
+        status: 'upcoming',
+      },
+    ],
+    checklist: [
+      { id: 'cl-1', label: 'Medication hold confirmed', complete: true },
+      { id: 'cl-2', label: 'Lab results synced', complete: true },
+      { id: 'cl-3', label: 'Consent awaiting signature', complete: false, note: 'Reminder sent 10m ago' },
+    ],
+    metrics: [
+      { label: 'Readiness score', value: '92', delta: '+4', tone: 'positive' },
+      { label: 'Tasks cleared', value: '17 / 20', delta: '+2 today', tone: 'neutral' },
+      { label: 'Escalations open', value: '1', delta: '-1 vs. avg', tone: 'positive' },
+    ],
+    chart: {
+      label: 'Readiness trajectory',
+      data: [
+        { step: 'Intake', score: 48 },
+        { step: 'Risk review', score: 63 },
+        { step: 'Clinician huddle', score: 78 },
+        { step: 'Today', score: 92 },
+      ],
+    },
+  },
+  {
+    id: 'patient',
+    label: 'Patient',
+    persona: 'Hannah Young',
+    headline: 'Know exactly what to do before surgery',
+    description:
+      'Patients receive guided tasks, friendly nudges, and human check-ins that match their confidence level.',
+    timeline: [
+      {
+        id: 'pt-1',
+        time: 'Today',
+        title: 'Review fasting guide',
+        detail: 'Interactive module finished, comprehension score 92%.',
+        status: 'complete',
+      },
+      {
+        id: 'pt-2',
+        time: 'Tomorrow',
+        title: 'Chlorhexidine rinse',
+        detail: 'Patient scheduled reminder and marked supplies delivered.',
+        status: 'active',
+      },
+      {
+        id: 'pt-3',
+        time: 'Surgery day',
+        title: 'Arrival checklist',
+        detail: 'Wayfinding and parking instructions pinned to mobile wallet.',
+        status: 'upcoming',
+      },
+    ],
+    checklist: [
+      { id: 'ptc-1', label: 'Informed consent passcode verified', complete: true },
+      { id: 'ptc-2', label: 'Protein intake logged', complete: false, note: 'Goal 85g daily' },
+      { id: 'ptc-3', label: 'Support contact confirmed', complete: true },
+    ],
+    metrics: [
+      { label: 'Confidence index', value: '87', delta: '+11 after coaching', tone: 'positive' },
+      { label: 'Daily streak', value: '5 days', tone: 'neutral' },
+      { label: 'Messages unread', value: '0', delta: 'All caught up', tone: 'positive' },
+    ],
+    chart: {
+      label: 'Engagement trend',
+      data: [
+        { step: 'Week -2', score: 54 },
+        { step: 'Week -1', score: 68 },
+        { step: 'This week', score: 83 },
+        { step: 'Today', score: 87 },
+      ],
+    },
+  },
+  {
+    id: 'recovery',
+    label: 'Recovery',
+    persona: 'Post-op Coach',
+    headline: 'Adapt recovery with live signal monitoring',
+    description:
+      'Recovery dashboards blend patient reported outcomes with wearable streams so clinicians intervene at the right moment.',
+    timeline: [
+      {
+        id: 'rc-1',
+        time: 'Post-op Day 1',
+        title: 'Pain survey received',
+        detail: 'Flagged as moderate and assigned nurse follow-up.',
+        status: 'complete',
+      },
+      {
+        id: 'rc-2',
+        time: 'Post-op Day 4',
+        title: 'Mobility milestone met',
+        detail: 'Steps goal achieved, wearable sync confirmed.',
+        status: 'active',
+      },
+      {
+        id: 'rc-3',
+        time: 'Upcoming',
+        title: 'Virtual wound check',
+        detail: 'Consent module queued with educational snippets.',
+        status: 'upcoming',
+      },
+    ],
+    checklist: [
+      { id: 'rcc-1', label: 'Symptom triage note sent', complete: true },
+      { id: 'rcc-2', label: 'Recovery slider updated', complete: false, note: 'Patient expects 6 days' },
+      { id: 'rcc-3', label: 'Care circle synced', complete: true },
+    ],
+    metrics: [
+      { label: 'Recovery time goal', value: '6 days', delta: '-1.5 vs. baseline', tone: 'positive' },
+      { label: 'Check-ins automated', value: '12', delta: 'this week', tone: 'neutral' },
+      { label: 'Alerts unresolved', value: '0', tone: 'positive' },
+    ],
+    chart: {
+      label: 'Healing confidence',
+      data: [
+        { step: 'Day 1', score: 61 },
+        { step: 'Day 3', score: 72 },
+        { step: 'Day 5', score: 81 },
+        { step: 'Today', score: 89 },
+      ],
+    },
+  },
+];
+
+export const actionPlanColumns: ActionPlanColumn[] = [
+  {
+    id: 'now',
+    title: 'Now',
+    description: 'Immediate priorities to launch the pilot experience.',
+    focus: 'Align care navigation workflows and compliance gates.',
+    tasks: [
+      {
+        id: 'now-1',
+        title: 'Design navigator readiness cockpit',
+        owner: 'Product',
+        status: 'In Flight',
+        note: 'Prototype linked in Figma with consent escalation states.',
+      },
+      {
+        id: 'now-2',
+        title: 'Integrate consent e-signature API',
+        owner: 'Engineering',
+        status: 'Planned',
+        note: 'Waiting on legal review for vendor agreement.',
+      },
+      {
+        id: 'now-3',
+        title: 'Map perioperative data feeds',
+        owner: 'Data Science',
+        status: 'In Flight',
+        note: 'HL7 ADT stream validated; wearable integration pending.',
+      },
+    ],
+  },
+  {
+    id: 'next',
+    title: 'Next',
+    description: 'Sequenced initiatives that deepen personalization.',
+    focus: 'Expand patient guidance modules and analytics loops.',
+    tasks: [
+      {
+        id: 'next-1',
+        title: 'Launch patient confidence scoring',
+        owner: 'Behavioral Science',
+        status: 'Planned',
+        note: 'Needs translation review and tone calibration.',
+      },
+      {
+        id: 'next-2',
+        title: 'Automate nurse escalation routing',
+        owner: 'Operations',
+        status: 'Planned',
+        note: 'Define thresholds with clinical governance council.',
+      },
+      {
+        id: 'next-3',
+        title: 'Embed analytics pulse into EHR',
+        owner: 'Engineering',
+        status: 'Blocked',
+        note: 'Awaiting Epic App Orchard sandbox approval.',
+      },
+    ],
+  },
+  {
+    id: 'later',
+    title: 'Later',
+    description: 'Strategic investments for scale and differentiation.',
+    focus: 'Optimize recovery intelligence and partner network.',
+    tasks: [
+      {
+        id: 'later-1',
+        title: 'Introduce wearable partner marketplace',
+        owner: 'Partnerships',
+        status: 'Planned',
+        note: 'Targeting Q3 vendor showcase.',
+      },
+      {
+        id: 'later-2',
+        title: 'Predictive staffing insights',
+        owner: 'Data Science',
+        status: 'Planned',
+        note: 'Requires longitudinal outcomes dataset.',
+      },
+      {
+        id: 'later-3',
+        title: 'Recovery community loops',
+        owner: 'Patient Experience',
+        status: 'Planned',
+        note: 'Design moderated groups with clinical oversight.',
+      },
+    ],
+  },
+];
+
+export const techStackLayers: TechStackLayer[] = [
+  {
+    id: 'frontend',
+    label: 'Frontend Experience',
+    description: 'Craft immersive clinician and patient surfaces that adapt to context.',
+    items: [
+      {
+        name: 'Next.js App Router',
+        summary: 'Server-driven routing with streaming UI for real-time care updates.',
+        interaction: 'Delivers navigator workspace transitions and hydration for checklists.',
+      },
+      {
+        name: 'Framer Motion',
+        summary: 'Declarative motion primitives for timelines and guided flows.',
+        interaction: 'Animates hero carousel progress and scenario transitions.',
+      },
+      {
+        name: 'Tailwind CSS + tokens',
+        summary: 'Design system tokens that keep typography and color consistent.',
+        interaction: 'Applies mode-aware gradients and precise layout rhythm.',
+      },
+    ],
+  },
+  {
+    id: 'backend',
+    label: 'Backend Services',
+    description: 'Secure orchestration layer that coordinates patient and clinician journeys.',
+    items: [
+      {
+        name: 'Node.js service mesh',
+        summary: 'Type-safe service layer for scheduling, consent, and messaging.',
+        interaction: 'Publishes readiness events that drive live navigator boards.',
+      },
+      {
+        name: 'GraphQL gateway',
+        summary: 'Unified schema for pulling tasks, metrics, and personalization data.',
+        interaction: 'Powers clinician and patient tabs without over-fetching.',
+      },
+      {
+        name: 'Auth0 workforce IAM',
+        summary: 'Fine-grained role access and audit trails for care teams.',
+        interaction: 'Enforces clinical scopes on escalation workflows.',
+      },
+    ],
+  },
+  {
+    id: 'data',
+    label: 'Data Intelligence',
+    description: 'Pipelines that shape raw clinical signals into decision-ready insights.',
+    items: [
+      {
+        name: 'Fivetran ingestion',
+        summary: 'Managed connectors for EHR, wearables, and patient engagement tools.',
+        interaction: 'Feeds the readiness trajectory models nightly.',
+      },
+      {
+        name: 'dbt semantic layer',
+        summary: 'Re-usable transformations define readiness, risk, and sentiment metrics.',
+        interaction: 'Generates codified KPIs for the metrics callouts.',
+      },
+      {
+        name: 'Vertex AI personalization',
+        summary: 'Predictive models tailor recovery suggestions and risk stratification.',
+        interaction: 'Updates action plan focus areas from streaming telemetry.',
+      },
+    ],
+  },
+  {
+    id: 'infrastructure',
+    label: 'Infrastructure & Ops',
+    description: 'Reliability, compliance, and delivery foundations for regulated care.',
+    items: [
+      {
+        name: 'GKE multi-region',
+        summary: 'High availability clusters with automated compliance guardrails.',
+        interaction: 'Keeps navigator workspace live across hospital regions.',
+      },
+      {
+        name: 'HashiCorp Vault',
+        summary: 'Secret management and key rotation for sensitive integrations.',
+        interaction: 'Secures consent and messaging credentials end-to-end.',
+      },
+      {
+        name: 'Terraform blueprints',
+        summary: 'Infrastructure as code for clinics onboarding onto the platform.',
+        interaction: 'Bootstraps new health system environments in hours.',
+      },
+    ],
+  },
+];
+
+export const codex = {
+  heroSlides,
+  demoScenarios,
+  actionPlanColumns,
+  techStackLayers,
+};
+
+export type Codex = typeof codex;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,239 +1,165 @@
 "use client";
-import Image from 'next/image';
+
+import { useMemo, useState } from 'react';
 import { motion } from 'framer-motion';
-import { CheckCircle2, ClipboardCheck, ShieldCheck, Sparkle, Stethoscope } from 'lucide-react';
+import { ArrowRight, Compass, PlayCircle } from 'lucide-react';
 
-import { FeatureCard } from '@/components/FeatureCard';
-
-const features = [
-  {
-    icon: Sparkle,
-    title: 'Intelligent orchestration',
-    description:
-      'Automated outreach, reminders, and education dynamically adapt to each patient’s risk profile and progress.'
-  },
-  {
-    icon: ClipboardCheck,
-    title: 'Surgical readiness clarity',
-    description:
-      'Surface a live readiness score and actionable tasks so clinical teams can proactively remove barriers to surgery.'
-  },
-  {
-    icon: Stethoscope,
-    title: 'Clinician collaboration',
-    description:
-      'Unify perioperative teams with a shared workflow that aligns surgeons, nurses, and care navigators.'
-  },
-  {
-    icon: ShieldCheck,
-    title: 'Recovery confidence',
-    description:
-      'Deliver individualized recovery plans and symptom tracking that give patients peace of mind after discharge.'
-  }
-];
-
-const careJourney = [
-  {
-    title: 'Risk stratification',
-    description: 'AI flags pulmonary risk as moderate and schedules respiratory coaching.',
-    status: 'In Motion',
-    tone: 'accent'
-  },
-  {
-    title: 'Pre-op checklist',
-    description: 'Patient confirmed medication hold and completed fasting questionnaire.',
-    status: 'Completed',
-    tone: 'success'
-  },
-  {
-    title: 'Care navigator note',
-    description: 'Navigator escalated mobility concern to PT with same-day telehealth slot.',
-    status: 'Escalated',
-    tone: 'warning'
-  }
-];
+import { codex } from '@/data/codex';
+import { HeroShowcase } from '@/components/HeroShowcase';
+import { DemoScenarioTabs } from '@/components/DemoScenarioTabs';
+import { MetricCallouts } from '@/components/MetricCallouts';
 
 export default function Home() {
+  const { heroSlides, demoScenarios } = codex;
+  const [activeHeroSlideId, setActiveHeroSlideId] = useState(heroSlides[0]?.id ?? '');
+  const [activeScenarioId, setActiveScenarioId] = useState(demoScenarios[0]?.id ?? '');
+
+  const activeScenario = useMemo(
+    () => demoScenarios.find((scenario) => scenario.id === activeScenarioId) ?? demoScenarios[0],
+    [activeScenarioId, demoScenarios],
+  );
+
+  const heroIndex = useMemo(
+    () => heroSlides.findIndex((slide) => slide.id === activeHeroSlideId),
+    [heroSlides, activeHeroSlideId],
+  );
+
+  const sequenceProgress = useMemo(() => {
+    const heroProgress = heroIndex >= 0 ? (heroIndex + 1) / heroSlides.length : 0;
+    const scenarioProgress =
+      demoScenarios.findIndex((scenario) => scenario.id === activeScenario?.id) + 1;
+    return {
+      hero: Math.round(heroProgress * 100),
+      scenario: Math.round((scenarioProgress / demoScenarios.length) * 100),
+    };
+  }, [heroIndex, heroSlides.length, activeScenario?.id, demoScenarios]);
+
   return (
-    <section
-      className="relative min-h-screen overflow-hidden"
-      style={{
-        backgroundImage: "url('/patterns/grid.svg'), var(--color-background)",
-        backgroundSize: '10rem 10rem, cover',
-        backgroundRepeat: 'repeat, no-repeat'
-      }}
-    >
-      <div className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-white/30 via-transparent to-white/10 dark:from-[#0f172a]/40 dark:via-transparent dark:to-[#0f172a]/30" />
-      <main className="relative z-10 mx-auto flex w-full max-w-6xl flex-col gap-24 px-6 py-16 sm:py-24">
+    <div className="relative min-h-screen overflow-hidden bg-gradient-to-b from-background via-background-subtle/60 to-background">
+      <div className="pointer-events-none absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(59,130,246,0.12),_transparent_55%)]" />
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-16 px-6 py-12 sm:gap-20 sm:py-16 lg:py-24">
+        <motion.div initial={{ opacity: 0, y: 32 }} animate={{ opacity: 1, y: 0 }} transition={{ duration: 0.6 }}>
+          <HeroShowcase
+            id="hero-story"
+            slides={heroSlides}
+            activeSlideId={activeHeroSlideId}
+            onSlideChange={setActiveHeroSlideId}
+          />
+        </motion.div>
+
         <motion.section
-          className="grid items-center gap-16 lg:grid-cols-[1.05fr_0.95fr]"
-          initial="hidden"
-          animate="visible"
-          variants={{ hidden: {}, visible: {} }}
+          id="navigator-experience"
+          initial={{ opacity: 0, y: 40 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          viewport={{ once: true, margin: '-100px' }}
+          className="space-y-8 rounded-3xl border border-border/50 bg-surface/70 p-6 shadow-xl backdrop-blur sm:p-10"
         >
-          <div className="space-y-10 text-left">
-            <motion.div
-              initial={{ opacity: 0, y: -24 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6 }}
-              className="space-y-6"
-            >
-              <span
-                className="inline-flex items-center rounded-full px-4 py-2 text-sm font-semibold text-primary"
-                style={{ backgroundColor: 'rgba(200, 236, 255, 0.55)' }}
-              >
-                AI X US platform
-              </span>
-              <h1 className="text-heading-lg sm:text-heading-xl font-bold text-foreground">
-                Let’s End One Size Fits All Healthcare
-              </h1>
-              <p className="max-w-xl text-body-lg text-muted">
-                AI X US is optimizing patient outcomes by personalizing the surgical journey. We illuminate the path from
-                preparation through recovery so every patient, clinician, and care team member is informed and empowered.
+          <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+            <div className="space-y-3">
+              <p className="inline-flex items-center gap-2 rounded-full border border-accent/40 bg-accent/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-accent">
+                Navigator workspace
               </p>
-            </motion.div>
-            <motion.div
-              className="rounded-3xl border border-border bg-surface/80 p-8 shadow-lg backdrop-blur-sm"
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6, delay: 0.15 }}
-            >
-              <div className="flex flex-wrap items-center justify-between gap-3">
-                <div>
-                  <p className="text-body-sm font-semibold uppercase tracking-[0.25em] text-muted">Product simulation</p>
-                  <h2 className="mt-2 text-heading-xs font-bold text-foreground">Navigator workspace</h2>
-                </div>
-                <span className="rounded-full bg-[color:var(--color-primary-soft)]/40 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-primary">
-                  Live preview
-                </span>
-              </div>
-              <ul className="mt-8 space-y-6">
-                {careJourney.map((item) => (
-                  <li key={item.title} className="flex items-start gap-4">
-                    <span
-                      className="mt-1 flex h-9 w-9 items-center justify-center rounded-full shadow-inner"
-                      style={{
-                        backgroundColor:
-                          item.tone === 'success'
-                            ? 'rgba(34, 197, 94, 0.18)'
-                            : item.tone === 'warning'
-                              ? 'rgba(251, 191, 36, 0.18)'
-                              : 'rgba(125, 216, 255, 0.22)',
-                        color:
-                          item.tone === 'success'
-                            ? 'var(--color-success)'
-                            : item.tone === 'warning'
-                              ? 'var(--color-warning)'
-                              : 'var(--color-accent)'
-                      }}
-                    >
-                      <CheckCircle2 className="h-5 w-5" strokeWidth={1.8} />
-                    </span>
-                    <div>
-                      <div className="flex flex-wrap items-baseline gap-3">
-                        <p className="text-body-md font-semibold text-foreground">{item.title}</p>
-                        <span
-                          className="rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide"
-                          style={{
-                            backgroundColor:
-                              item.tone === 'success'
-                                ? 'rgba(34, 197, 94, 0.12)'
-                                : item.tone === 'warning'
-                                  ? 'rgba(251, 191, 36, 0.12)'
-                                  : 'rgba(125, 216, 255, 0.16)',
-                            color:
-                              item.tone === 'success'
-                                ? 'var(--color-success)'
-                                : item.tone === 'warning'
-                                  ? 'var(--color-warning)'
-                                  : 'var(--color-accent-contrast)'
-                          }}
-                        >
-                          {item.status}
-                        </span>
-                      </div>
-                      <p className="mt-2 text-body-sm text-muted">{item.description}</p>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-              <div className="mt-8 flex items-center gap-3 text-sm text-muted">
-                <span className="inline-flex h-2 w-2 rounded-full bg-primary" />
-                <span>Updated moments ago from our synthetic pre-op cohort run.</span>
-              </div>
-            </motion.div>
-            <motion.dl
-              className="grid gap-6 sm:grid-cols-2"
-              initial={{ opacity: 0, y: 30 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.6, delay: 0.25 }}
-            >
-              <div
-                className="rounded-2xl border border-border p-6 backdrop-blur"
-                style={{ backgroundColor: 'var(--color-surface)' }}
-              >
-                <dt className="text-body-sm uppercase tracking-[0.2em] text-muted">Surgical Readiness</dt>
-                <dd className="mt-2 flex items-baseline gap-3">
-                  <span className="text-5xl font-semibold text-[color:var(--color-score)]">92%</span>
-                  <span className="text-body-md text-muted">average readiness score</span>
-                </dd>
-              </div>
-              <div
-                className="rounded-2xl border border-border p-6 backdrop-blur"
-                style={{ backgroundColor: 'var(--color-surface)' }}
-              >
-                <dt className="text-body-sm uppercase tracking-[0.2em] text-muted">Task Completion</dt>
-                <dd className="mt-2 flex items-baseline gap-3">
-                  <span className="text-5xl font-semibold text-primary">48</span>
-                  <span className="text-body-md text-muted">critical tasks automated weekly</span>
-                </dd>
-              </div>
-            </motion.dl>
-          </div>
-          <motion.div
-            className="relative flex justify-center"
-            initial={{ opacity: 0, x: 40 }}
-            animate={{ opacity: 1, x: 0 }}
-            transition={{ duration: 0.7, delay: 0.2 }}
-          >
-            <div className="relative flex h-full w-full max-w-md flex-col items-center justify-center">
-              <div
-                className="absolute inset-0 -z-10 rounded-full blur-3xl"
-                style={{ backgroundColor: 'rgba(125, 216, 255, 0.45)' }}
-              />
-              <Image
-                src="/images/hero-app-1.svg"
-                alt="AIXUS mobile experience overview"
-                width={320}
-                height={640}
-                className="drop-shadow-2xl"
-              />
-              <Image
-                src="/images/hero-app-2.svg"
-                alt="Personalized care pathway on AIXUS"
-                width={300}
-                height={600}
-                className="-mt-24 w-[65%] -translate-x-12 drop-shadow-2xl sm:-translate-x-16"
-              />
+              <h2 className="text-heading-md font-semibold text-foreground sm:text-heading-lg">
+                Walk through the demo scenarios
+              </h2>
+              <p className="max-w-2xl text-body-md text-muted">
+                Flip personas to see how readiness, consent, and recovery cues stay orchestrated. The Codex keeps each scenario in lockstep with the hero narrative.
+              </p>
             </div>
-          </motion.div>
+            <div className="flex items-center gap-3 text-xs uppercase tracking-[0.4em] text-muted">
+              <PlayCircle className="h-4 w-4" />
+              Live simulation
+            </div>
+          </header>
+
+          <DemoScenarioTabs
+            scenarios={demoScenarios}
+            activeScenarioId={activeScenarioId}
+            onScenarioChange={setActiveScenarioId}
+          />
         </motion.section>
 
-        <section className="space-y-12">
-          <div className="max-w-2xl">
-            <h2 className="text-heading-md font-bold text-foreground">Care teams move faster with clarity.</h2>
-            <p className="mt-4 text-body-lg text-muted">
-              Clinicians, navigators, and patients gain a single shared operating picture. These experience pillars deliver the
-              confidence and calm needed to navigate the surgical journey without surprises.
+        <motion.section
+          id="codex-metrics"
+          initial={{ opacity: 0, y: 40 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.6 }}
+          viewport={{ once: true, margin: '-120px' }}
+          className="grid gap-10 lg:grid-cols-[0.8fr_1.2fr]"
+        >
+          <div className="rounded-3xl border border-border/60 bg-background-subtle/80 p-6 shadow-lg">
+            <h3 className="text-sm font-semibold uppercase tracking-[0.4em] text-muted">Codex journey tracker</h3>
+            <p className="mt-3 text-body-md text-muted">
+              Every interactive moment references the shared Codex. When you advance the hero or scenarios, progress and metrics update everywhere instantly.
             </p>
+            <div className="mt-6 space-y-6">
+              <div>
+                <div className="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-muted">
+                  <span>Hero storyline</span>
+                  <span>{sequenceProgress.hero}%</span>
+                </div>
+                <div className="mt-2 h-2 rounded-full bg-border/40">
+                  <motion.div
+                    className="h-full rounded-full bg-primary"
+                    animate={{ width: `${sequenceProgress.hero}%` }}
+                    transition={{ duration: 0.6, ease: 'easeInOut' }}
+                  />
+                </div>
+              </div>
+              <div>
+                <div className="flex items-center justify-between text-xs uppercase tracking-[0.35em] text-muted">
+                  <span>Scenario tour</span>
+                  <span>{sequenceProgress.scenario}%</span>
+                </div>
+                <div className="mt-2 h-2 rounded-full bg-border/40">
+                  <motion.div
+                    className="h-full rounded-full bg-accent"
+                    animate={{ width: `${sequenceProgress.scenario}%` }}
+                    transition={{ duration: 0.6, ease: 'easeInOut' }}
+                  />
+                </div>
+              </div>
+            </div>
+            <div className="mt-6 flex items-center gap-3 rounded-2xl border border-border/60 bg-background p-4 text-sm text-muted">
+              <Compass className="h-4 w-4" />
+              Guided breadcrumbs follow your selections in the global layout navigation.
+            </div>
           </div>
-          <div className="grid gap-8 md:grid-cols-2">
-            {features.map((feature, index) => (
-              <FeatureCard key={feature.title} {...feature} delay={0.1 * index} />
-            ))}
+
+          <div className="rounded-3xl border border-border/60 bg-surface/80 p-6 shadow-xl">
+            <div className="flex items-center justify-between">
+              <h3 className="text-sm font-semibold uppercase tracking-[0.35em] text-muted">Dynamic metrics</h3>
+              <span className="rounded-full border border-border/60 px-3 py-1 text-xs uppercase tracking-[0.4em] text-muted">
+                Codex synced
+              </span>
+            </div>
+            <p className="mt-3 text-body-md text-muted">
+              Metrics refresh as personas change, blending readiness, confidence, and recovery signals from the Codex dataset.
+            </p>
+            <div className="mt-6">
+              <MetricCallouts
+                metrics={(activeScenario?.metrics ?? []).map((metric) => ({
+                  label: metric.label,
+                  value: metric.value,
+                  delta: metric.delta,
+                  tone: metric.tone,
+                }))}
+                columns={2}
+                activeKey={activeScenario?.id}
+              />
+            </div>
+            <motion.div
+              className="mt-6 inline-flex items-center gap-2 rounded-full border border-primary/40 bg-primary/10 px-4 py-2 text-sm font-semibold text-primary"
+              animate={{ y: [0, -3, 0] }}
+              transition={{ duration: 3, repeat: Infinity }}
+            >
+              <ArrowRight className="h-4 w-4" />
+              Explore the plan to see how tasks align
+            </motion.div>
           </div>
-        </section>
-      </main>
-    </section>
+        </motion.section>
+      </div>
+    </div>
   );
 }

--- a/src/pages/plan.tsx
+++ b/src/pages/plan.tsx
@@ -1,174 +1,422 @@
 "use client";
 
 import { useEffect, useState } from 'react';
-import Link from 'next/link';
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  useSortable,
+  arrayMove,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { AnimatePresence, motion } from 'framer-motion';
+import { ArrowRight, Edit3, Plus, Target } from 'lucide-react';
 
-type Task = {
-  id: string;
-  title: string;
-  owner: string;
-};
-type Board = {
-  now: Task[];
-  next: Task[];
-  later: Task[];
-};
+import { actionPlanColumns, type ActionPlanColumn, type ActionPlanTask } from '@/data/codex';
 
-export default function PlanPage() {
-  const [board, setBoard] = useState<Board>({ now: [], next: [], later: [] });
-  const [filterOwner, setFilterOwner] = useState('');
-  const [dragged, setDragged] = useState<{ id: string; from: keyof Board } | null>(null);
+interface BoardColumn extends ActionPlanColumn {}
 
-  // Load from localStorage on mount
-  useEffect(() => {
-    const stored = localStorage.getItem('actionPlanBoard');
-    if (stored) {
-      setBoard(JSON.parse(stored));
-    } else {
-      const initial: Board = {
-        now: [
-          { id: genId(), title: 'Define patient tasks', owner: 'Hannah' },
-          { id: genId(), title: 'Collect surgical readiness data', owner: 'Clinician' },
-        ],
-        next: [
-          { id: genId(), title: 'Implement informed consent flow', owner: 'Developer' },
-        ],
-        later: [
-          { id: genId(), title: 'Analyse recovery metrics', owner: 'Data Scientist' },
-        ],
-      };
-      setBoard(initial);
-    }
-  }, []);
-  // Persist board to localStorage whenever it changes
-  useEffect(() => {
-    localStorage.setItem('actionPlanBoard', JSON.stringify(board));
-  }, [board]);
+interface EditorState {
+  mode: 'create' | 'edit';
+  columnId: string;
+  task: ActionPlanTask;
+}
 
-  const statuses: (keyof Board)[] = ['now', 'next', 'later'];
-
-  const addTask = (status: keyof Board) => {
-    const title = prompt('Task title:');
-    if (!title) return;
-    const owner = prompt('Owner (optional):') || '';
-    const newTask: Task = { id: genId(), title: title.trim(), owner: owner.trim() };
-    setBoard((prev) => ({ ...prev, [status]: [...prev[status], newTask] }));
+function createEmptyTask(): ActionPlanTask {
+  const id = typeof crypto !== 'undefined' && 'randomUUID' in crypto ? crypto.randomUUID() : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  return {
+    id: `task-${id}`,
+    title: '',
+    owner: '',
+    status: 'Planned',
+    note: '',
   };
+}
 
-  const handleDragStart = (task: Task, from: keyof Board) => {
-    setDragged({ id: task.id, from });
-  };
-  const handleDrop = (to: keyof Board) => {
-    if (!dragged) return;
-    const { id, from } = dragged;
-    if (from === to) return;
-    let movedTask: Task | undefined;
-    setBoard((prev) => {
-      const newPrev: Board = { ...prev, [from]: [...prev[from]], [to]: [...prev[to]] };
-      newPrev[from] = newPrev[from].filter((t) => {
-        if (t.id === id) {
-          movedTask = t;
-          return false;
-        }
-        return true;
-      });
-      if (movedTask) {
-        newPrev[to].push(movedTask);
-      }
-      return newPrev;
-    });
-    setDragged(null);
-  };
+function SortableTaskCard({
+  task,
+  columnId,
+  onSelect,
+}: {
+  task: ActionPlanTask;
+  columnId: string;
+  onSelect: () => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: task.id,
+    data: { columnId },
+  });
 
-  const exportBoard = () => {
-    const dataStr = JSON.stringify(board, null, 2);
-    const blob = new Blob([dataStr], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = 'action-plan.json';
-    link.click();
-    URL.revokeObjectURL(url);
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
   };
 
   return (
-    <main className="min-h-screen bg-background text-foreground p-6">
-      <header className="text-center mb-6 space-y-2">
-        <h1 className="text-heading-md sm:text-heading-lg font-bold">Action Plan Board</h1>
-        <p className="text-muted text-body-md max-w-3xl mx-auto">
-          Organise tasks by priority and track progress. Drag tasks between the Now, Next and Later columns,
-          filter by owner, or export your plan as JSON.
-        </p>
-        <Link href="/" className="inline-block px-4 py-2 rounded-md border border-border bg-background text-foreground font-semibold transition-colors hover:border-primary hover:text-primary hover:bg-background-subtle">
-          Back to Home
-        </Link>
-      </header>
-      <div className="flex flex-wrap gap-2 mb-4 items-center">
-        <input
-          value={filterOwner}
-          onChange={(e) => setFilterOwner(e.target.value)}
-          placeholder="Filter by owner (optional)"
-          className="flex-1 min-w-[12rem] px-3 py-2 rounded-md border border-border bg-surface text-body-sm text-foreground placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-primary/40"
-        />
-        <button
-          onClick={() => setFilterOwner('')}
-          className="px-3 py-2 rounded-md bg-primary text-primary-contrast font-semibold transition-colors hover:bg-primary-strong"
-        >
-          Clear Filter
-        </button>
-        <button
-          onClick={exportBoard}
-          className="px-3 py-2 rounded-md bg-primary text-primary-contrast font-semibold transition-colors hover:bg-primary-strong"
-        >
-          Export JSON
-        </button>
+    <motion.button
+      ref={setNodeRef}
+      layout
+      style={style}
+      whileHover={{ scale: 1.02 }}
+      whileTap={{ scale: 0.98 }}
+      onClick={onSelect}
+      className={`flex w-full flex-col gap-2 rounded-2xl border border-border/60 bg-background-subtle/80 p-4 text-left shadow-sm transition-shadow focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 ${isDragging ? 'shadow-2xl ring-2 ring-primary/40' : ''}`}
+      {...attributes}
+      {...listeners}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-body-md font-semibold text-foreground">{task.title || 'Untitled task'}</p>
+        <span className="rounded-full border border-border/60 bg-background px-2 py-1 text-[0.7rem] font-semibold uppercase tracking-[0.3em] text-muted">
+          {task.status}
+        </span>
       </div>
-      <div className="flex flex-wrap gap-4">
-        {statuses.map((status) => {
-          const tasks = board[status];
-          return (
-            <div
-              key={status}
-              className="flex-1 min-w-[250px] bg-surface rounded-lg p-4 shadow-md flex flex-col border border-border"
-              onDragOver={(e) => e.preventDefault()}
-              onDrop={() => handleDrop(status)}
-            >
-              <h2 className="text-heading-xs font-semibold text-center mb-2 capitalize">{status}</h2>
-              <div className="flex-1 space-y-2 overflow-y-auto">
-                {tasks
-                  .filter((t) =>
-                    filterOwner
-                      ? t.owner.toLowerCase().includes(filterOwner.toLowerCase())
-                      : true
-                  )
-                  .map((task) => (
-                    <div
-                      key={task.id}
-                      draggable
-                      onDragStart={() => handleDragStart(task, status)}
-                      className="bg-background-subtle p-2 rounded-md cursor-grab shadow-sm border border-border"
-                    >
-                      <div className="font-semibold text-body-sm text-foreground">{task.title}</div>
-                      {task.owner && (
-                        <div className="text-xs text-neutral-400">{task.owner}</div>
-                      )}
-                    </div>
-                  ))}
-              </div>
-              <button
-                onClick={() => addTask(status)}
-                className="mt-2 px-3 py-1 rounded-md bg-primary-soft text-primary-strong text-body-sm font-semibold transition-colors hover:bg-primary"
-              >
-                + Add Task
-              </button>
-            </div>
-          );
-        })}
+      <div className="flex items-center gap-2 text-xs text-muted">
+        <Edit3 className="h-3.5 w-3.5" />
+        <span>{task.owner || 'Unassigned'}</span>
       </div>
-    </main>
+      {task.note && <p className="text-sm text-muted">{task.note}</p>}
+    </motion.button>
   );
 }
 
-function genId() {
-  return Date.now().toString(36) + Math.random().toString(36).slice(2, 7);
+function TaskEditor({
+  state,
+  onClose,
+  onSave,
+}: {
+  state: EditorState | null;
+  onClose: () => void;
+  onSave: (state: EditorState) => void;
+}) {
+  const [formState, setFormState] = useState(state);
+
+  useEffect(() => {
+    setFormState(state);
+  }, [state]);
+
+  if (!state || !formState) return null;
+
+  const { task } = formState;
+
+  const handleChange = (key: keyof ActionPlanTask, value: string) => {
+    setFormState((prev) =>
+      prev
+        ? {
+            ...prev,
+            task: {
+              ...prev.task,
+              [key]: value,
+            },
+          }
+        : prev,
+    );
+  };
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!formState) return;
+    onSave(formState);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end justify-end bg-black/40 backdrop-blur-sm">
+      <motion.div
+        initial={{ x: 320, opacity: 0 }}
+        animate={{ x: 0, opacity: 1 }}
+        exit={{ x: 320, opacity: 0 }}
+        transition={{ duration: 0.35 }}
+        className="h-full w-full max-w-md overflow-y-auto border-l border-border/60 bg-background p-6 shadow-2xl"
+      >
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-[0.35em] text-muted">{formState.mode === 'create' ? 'Create task' : 'Edit task'}</p>
+            <h2 className="mt-2 text-heading-xs font-semibold text-foreground">{task.title || 'New initiative'}</h2>
+            <p className="text-xs text-muted">Column: {formState.columnId.toUpperCase()}</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full border border-border/60 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-muted hover:text-foreground"
+          >
+            Close
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-[0.3em] text-muted">Title</label>
+            <input
+              value={task.title}
+              onChange={(event) => handleChange('title', event.target.value)}
+              className="mt-2 w-full rounded-xl border border-border/60 bg-background-subtle px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+              placeholder="Describe the task"
+              required
+            />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label className="text-xs font-semibold uppercase tracking-[0.3em] text-muted">Owner</label>
+              <input
+                value={task.owner}
+                onChange={(event) => handleChange('owner', event.target.value)}
+                className="mt-2 w-full rounded-xl border border-border/60 bg-background-subtle px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+                placeholder="Assign an owner"
+              />
+            </div>
+            <div>
+              <label className="text-xs font-semibold uppercase tracking-[0.3em] text-muted">Status</label>
+              <select
+                value={task.status}
+                onChange={(event) => handleChange('status', event.target.value)}
+                className="mt-2 w-full rounded-xl border border-border/60 bg-background-subtle px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+              >
+                <option value="Planned">Planned</option>
+                <option value="In Flight">In Flight</option>
+                <option value="Blocked">Blocked</option>
+                <option value="Complete">Complete</option>
+              </select>
+            </div>
+          </div>
+          <div>
+            <label className="text-xs font-semibold uppercase tracking-[0.3em] text-muted">Notes</label>
+            <textarea
+              value={task.note ?? ''}
+              onChange={(event) => handleChange('note', event.target.value)}
+              className="mt-2 h-28 w-full rounded-xl border border-border/60 bg-background-subtle px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/40"
+              placeholder="Add context or links"
+            />
+          </div>
+          <div className="flex items-center justify-between gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-xl border border-border/60 px-4 py-2 text-sm font-semibold text-muted hover:text-foreground"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="rounded-xl border border-primary/40 bg-primary/10 px-4 py-2 text-sm font-semibold text-primary hover:bg-primary/20"
+            >
+              Save changes
+            </button>
+          </div>
+        </form>
+      </motion.div>
+    </div>
+  );
+}
+
+export default function PlanPage() {
+  const [columns, setColumns] = useState<BoardColumn[]>(() =>
+    actionPlanColumns.map((column) => ({ ...column, tasks: [...column.tasks] })),
+  );
+  const [activeTask, setActiveTask] = useState<ActionPlanTask | null>(null);
+  const [editorState, setEditorState] = useState<EditorState | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 6 },
+    }),
+  );
+
+  const handleDragStart = (event: DragStartEvent) => {
+    const taskId = event.active.id as string;
+    const columnId = event.active.data.current?.columnId as string | undefined;
+    const column = columns.find((col) => col.id === columnId) ?? columns.find((col) => col.tasks.some((task) => task.id === taskId));
+    const task = column?.tasks.find((item) => item.id === taskId) ?? null;
+    setActiveTask(task ?? null);
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over) {
+      setActiveTask(null);
+      return;
+    }
+    const activeId = active.id as string;
+    const overId = over.id as string;
+    const originColumnId = (active.data.current?.columnId as string) ??
+      columns.find((column) => column.tasks.some((task) => task.id === activeId))?.id;
+    const overColumnId = (over.data.current?.columnId as string) ??
+      columns.find((column) => column.tasks.some((task) => task.id === overId))?.id ?? overId;
+
+    const originColumnIndex = columns.findIndex((column) => column.id === originColumnId);
+    const targetColumnIndex = columns.findIndex((column) => column.id === overColumnId);
+
+    if (originColumnIndex === -1 || targetColumnIndex === -1) {
+      setActiveTask(null);
+      return;
+    }
+
+    setColumns((prev) => {
+      const updated = prev.map((column) => ({ ...column, tasks: [...column.tasks] }));
+      const originColumn = updated[originColumnIndex];
+      const targetColumn = updated[targetColumnIndex];
+
+      const activeIndex = originColumn.tasks.findIndex((task) => task.id === activeId);
+
+      if (originColumn.id === targetColumn.id) {
+        const overTaskIndex = targetColumn.tasks.findIndex((task) => task.id === overId);
+        const newIndex = overTaskIndex >= 0 ? overTaskIndex : targetColumn.tasks.length - 1;
+        originColumn.tasks = arrayMove(originColumn.tasks, activeIndex, newIndex);
+        updated[originColumnIndex] = { ...originColumn };
+        return updated;
+      }
+
+      const [movedTask] = originColumn.tasks.splice(activeIndex, 1);
+      const overTaskIndex = targetColumn.tasks.findIndex((task) => task.id === overId);
+      const insertIndex = overTaskIndex >= 0 ? overTaskIndex : targetColumn.tasks.length;
+      targetColumn.tasks.splice(insertIndex, 0, movedTask);
+
+      updated[originColumnIndex] = { ...originColumn };
+      updated[targetColumnIndex] = { ...targetColumn };
+      return updated;
+    });
+
+    setActiveTask(null);
+  };
+
+  const openEditor = (columnId: string, task: ActionPlanTask, mode: EditorState['mode']) => {
+    setEditorState({ columnId, task: { ...task }, mode });
+  };
+
+  const handleEditorSave = (state: EditorState) => {
+    setColumns((prev) => {
+      const updated = prev.map((column) => ({ ...column, tasks: [...column.tasks] }));
+      const columnIndex = updated.findIndex((column) => column.id === state.columnId);
+      if (columnIndex === -1) return prev;
+
+      const column = updated[columnIndex];
+      const existingIndex = column.tasks.findIndex((task) => task.id === state.task.id);
+
+      if (existingIndex >= 0) {
+        column.tasks[existingIndex] = state.task;
+      } else {
+        column.tasks.unshift(state.task);
+      }
+
+      updated[columnIndex] = { ...column };
+      return updated;
+    });
+    setEditorState(null);
+  };
+
+  return (
+    <main className="min-h-screen bg-gradient-to-b from-background via-background-subtle to-background text-foreground">
+      <div className="mx-auto w-full max-w-6xl px-6 py-12">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div className="space-y-3">
+            <p className="inline-flex items-center gap-2 rounded-full border border-primary/40 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-primary">
+              Orchestration plan
+            </p>
+            <h1 className="text-heading-md font-semibold text-foreground sm:text-heading-lg">
+              Align the now, next, and later roadmap
+            </h1>
+            <p className="max-w-3xl text-body-md text-muted">
+              Drag tasks between swim lanes, edit details inline, and keep the Codex synced so every stakeholder sees the same action plan.
+            </p>
+          </div>
+          <div className="flex items-center gap-3 text-xs uppercase tracking-[0.4em] text-muted">
+            <Target className="h-4 w-4" /> Focused cadence
+          </div>
+        </header>
+
+        <div className="mt-10 grid gap-8 lg:grid-cols-[1.35fr_0.65fr]">
+          <div className="rounded-3xl border border-border/50 bg-surface/80 p-6 shadow-xl backdrop-blur">
+            <DndContext
+              sensors={sensors}
+              onDragStart={handleDragStart}
+              onDragEnd={handleDragEnd}
+            >
+              <div className="grid gap-4 md:grid-cols-3">
+                {columns.map((column) => {
+                  const { setNodeRef } = useDroppable({ id: column.id, data: { columnId: column.id } });
+                  return (
+                    <motion.div
+                      key={column.id}
+                      ref={setNodeRef}
+                      layout
+                      className="flex h-full flex-col gap-4 rounded-2xl border border-border/60 bg-background-subtle/80 p-4 shadow-lg"
+                    >
+                      <div className="space-y-1">
+                        <p className="text-xs font-semibold uppercase tracking-[0.35em] text-muted">{column.title}</p>
+                        <p className="text-body-sm text-muted">{column.description}</p>
+                        <p className="text-xs text-muted/80">Focus: {column.focus}</p>
+                      </div>
+                    <SortableContext items={column.tasks.map((task) => task.id)} strategy={verticalListSortingStrategy}>
+                      <div className="flex flex-1 flex-col gap-3">
+                        {column.tasks.map((task) => (
+                          <SortableTaskCard
+                            key={task.id}
+                            task={task}
+                            columnId={column.id}
+                            onSelect={() => openEditor(column.id, task, 'edit')}
+                          />
+                        ))}
+                        <button
+                          type="button"
+                          onClick={() => openEditor(column.id, createEmptyTask(), 'create')}
+                          className="flex items-center justify-center gap-2 rounded-2xl border border-dashed border-primary/40 bg-primary/5 py-3 text-sm font-semibold text-primary transition-colors hover:bg-primary/10"
+                        >
+                          <Plus className="h-4 w-4" /> Add task
+                        </button>
+                      </div>
+                    </SortableContext>
+                    </motion.div>
+                  );
+                })}
+              </div>
+
+              <DragOverlay>
+                {activeTask ? (
+                  <motion.div className="w-64 rounded-2xl border border-primary/40 bg-background-subtle/90 p-4 shadow-2xl">
+                    <p className="text-sm font-semibold text-foreground">{activeTask.title}</p>
+                    <p className="mt-1 text-xs text-muted">{activeTask.owner || 'Unassigned'}</p>
+                  </motion.div>
+                ) : null}
+              </DragOverlay>
+            </DndContext>
+          </div>
+
+          <aside className="space-y-6 rounded-3xl border border-border/50 bg-background-subtle/80 p-6 shadow-lg">
+            <div className="flex items-center justify-between">
+              <h2 className="text-sm font-semibold uppercase tracking-[0.35em] text-muted">Codex summary</h2>
+              <span className="rounded-full border border-border/60 px-3 py-1 text-xs uppercase tracking-[0.4em] text-muted">
+                Synced
+              </span>
+            </div>
+            <p className="text-sm text-muted">
+              The action plan pulls straight from the Codex. Updating tasks here keeps hero stories, demos, and stack narratives consistent.
+            </p>
+            <ul className="space-y-4">
+              {columns.map((column) => (
+                <li key={column.id} className="rounded-2xl border border-border/60 bg-background p-4">
+                  <p className="text-xs font-semibold uppercase tracking-[0.3em] text-muted">{column.title}</p>
+                  <p className="mt-2 text-sm text-muted">{column.focus}</p>
+                  <div className="mt-3 flex items-center justify-between text-xs text-muted">
+                    <span>{column.tasks.length} tasks</span>
+                    <span className="inline-flex items-center gap-1 text-primary">
+                      View lane <ArrowRight className="h-3.5 w-3.5" />
+                    </span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </aside>
+        </div>
+      </div>
+
+      <AnimatePresence>{editorState && <TaskEditor state={editorState} onClose={() => setEditorState(null)} onSave={handleEditorSave} />}</AnimatePresence>
+    </main>
+  );
 }

--- a/src/pages/stack.tsx
+++ b/src/pages/stack.tsx
@@ -1,135 +1,129 @@
 "use client";
-import { useState } from 'react';
-import { ChevronDown, ChevronUp } from 'lucide-react';
-import { motion, AnimatePresence } from 'framer-motion';
 
-interface SectionItem {
-  title: string;
-  description: string;
-}
+import { useMemo, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+import { Layers, Server, Sparkles } from 'lucide-react';
 
-interface Section {
-  title: string;
-  items: SectionItem[];
-}
-
-const sections: Section[] = [
-  {
-    title: "Frontend Framework",
-    items: [
-      {
-        title: "Next.js",
-        description: "Next.js powers the app with server‑side rendering and routing",
-      },
-      {
-        title: "React",
-        description: "The underlying library for building the user interface",
-      },
-      {
-        title: "TypeScript",
-        description: "Adds static typing for safer and more robust code",
-      },
-    ],
-  },
-  {
-    title: "Styling",
-    items: [
-      {
-        title: "Tailwind CSS",
-        description: "A utility‑first CSS framework for custom designs",
-      },
-      {
-        title: "shadcn/ui",
-        description:
-          "A component library built with Radix and Tailwind CSS for accessible UI primitives",
-      },
-    ],
-  },
-  {
-    title: "Charts & Visualization",
-    items: [
-      {
-        title: "Recharts",
-        description: "A library for building elegant charts in React",
-      },
-    ],
-  },
-  {
-    title: "Animations",
-    items: [
-      {
-        title: "Framer Motion",
-        description: "A library for declarative animations in React",
-      },
-    ],
-  },
-];
+import { techStackLayers } from '@/data/codex';
 
 export default function TechStack() {
-  const [openSections, setOpenSections] = useState<number[]>([]);
+  const [activeLayerId, setActiveLayerId] = useState(techStackLayers[0]?.id ?? 'frontend');
 
-  const toggleSection = (index: number) => {
-    setOpenSections((prev) =>
-      prev.includes(index) ? prev.filter((i) => i !== index) : [...prev, index]
-    );
-  };
+  const activeLayer = useMemo(
+    () => techStackLayers.find((layer) => layer.id === activeLayerId) ?? techStackLayers[0],
+    [activeLayerId],
+  );
 
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 30 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.5 }}
-      className="max-w-3xl mx-auto bg-background text-foreground p-6 text-left"
-    >
-      <h1 className="text-heading-md font-bold mb-4">Our Technology Stack</h1>
-      <p className="mb-6 text-body-md text-muted">
-        Explore the tools and technologies that power the AIXUS platform.
-      </p>
-      <div className="space-y-4">
-        {sections.map((section, index) => {
-          const isOpen = openSections.includes(index);
-          return (
+    <main className="min-h-screen bg-gradient-to-b from-background via-background-subtle to-background text-foreground">
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-10 px-6 py-12 sm:gap-12 sm:py-16">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div className="space-y-3">
+            <p className="inline-flex items-center gap-2 rounded-full border border-primary/40 bg-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-primary">
+              Codex stack
+            </p>
+            <h1 className="text-heading-md font-semibold text-foreground sm:text-heading-lg">
+              Explore the layers powering AIXUS
+            </h1>
+            <p className="max-w-2xl text-body-md text-muted">
+              Toggle between frontend, backend, data, and infrastructure to see how each layer supports the orchestrated care experience.
+            </p>
+          </div>
+          <div className="flex items-center gap-3 text-xs uppercase tracking-[0.4em] text-muted">
+            <Layers className="h-4 w-4" /> Structured Codex
+          </div>
+        </header>
+
+        <section className="rounded-3xl border border-border/50 bg-surface/80 p-6 shadow-xl backdrop-blur sm:p-10">
+          <div className="flex flex-wrap items-center gap-3">
+            {techStackLayers.map((layer) => {
+              const isActive = layer.id === activeLayer.id;
+              return (
+                <button
+                  key={layer.id}
+                  type="button"
+                  onClick={() => setActiveLayerId(layer.id)}
+                  className={`group relative overflow-hidden rounded-full border px-4 py-2 text-sm font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 ${isActive ? 'border-primary/60 bg-primary/10 text-primary' : 'border-border/60 bg-background-subtle text-muted hover:text-foreground'}`}
+                >
+                  <span className="flex items-center gap-2">
+                    <Server className={`h-4 w-4 transition-colors ${isActive ? 'text-primary' : 'text-muted'}`} />
+                    {layer.label}
+                  </span>
+                  {isActive && (
+                    <motion.span
+                      layoutId="stack-tab"
+                      className="absolute inset-x-2 bottom-1 h-0.5 rounded-full bg-primary"
+                    />
+                  )}
+                </button>
+              );
+            })}
+          </div>
+
+          <AnimatePresence mode="wait">
             <motion.div
-              layout
-              key={section.title}
-              initial={{ opacity: 0, y: 10 }}
+              key={activeLayer.id}
+              initial={{ opacity: 0, y: 32 }}
               animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.3 }}
-              className="border border-border rounded-lg overflow-hidden bg-surface shadow-sm"
+              exit={{ opacity: 0, y: -24 }}
+              transition={{ duration: 0.45 }}
+              className="mt-8 space-y-6"
             >
-              <button
-                className="flex justify-between items-center w-full px-4 py-3 bg-surface-muted hover:bg-background-subtle transition-colors text-foreground"
-                onClick={() => toggleSection(index)}
-              >
-                <span className="font-semibold">{section.title}</span>
-                {isOpen ? (
-                  <ChevronUp className="w-5 h-5" />
-                ) : (
-                  <ChevronDown className="w-5 h-5" />
-                )}
-              </button>
-              <AnimatePresence initial={false}>
-                {isOpen && (
+              <div className="rounded-2xl border border-border/60 bg-background-subtle/80 p-6 shadow-lg">
+                <p className="text-xs font-semibold uppercase tracking-[0.35em] text-muted">{activeLayer.label}</p>
+                <p className="mt-3 text-body-md text-muted">{activeLayer.description}</p>
+              </div>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                {activeLayer.items.map((item) => (
                   <motion.div
-                    initial={{ height: 0, opacity: 0 }}
-                    animate={{ height: 'auto', opacity: 1 }}
-                    exit={{ height: 0, opacity: 0 }}
-                    transition={{ duration: 0.3 }}
-                    className="px-4 py-3 bg-background-subtle space-y-2"
+                    key={item.name}
+                    layout
+                    className="group flex h-full flex-col justify-between rounded-2xl border border-border/60 bg-background p-5 shadow-md transition-transform hover:-translate-y-1"
                   >
-                    {section.items.map((item) => (
-                      <div key={item.title}>
-                        <h3 className="font-medium">{item.title}</h3>
-                        <p className="text-muted">{item.description}</p>
+                    <div className="space-y-3">
+                      <div className="flex items-center justify-between">
+                        <h2 className="text-heading-xs font-semibold text-foreground">{item.name}</h2>
+                        <motion.span
+                          className="rounded-full border border-primary/40 bg-primary/10 px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-primary"
+                          initial={{ opacity: 0, scale: 0.9 }}
+                          animate={{ opacity: 1, scale: 1 }}
+                          transition={{ duration: 0.35 }}
+                        >
+                          Active
+                        </motion.span>
                       </div>
-                    ))}
+                      <p className="text-sm text-muted">{item.summary}</p>
+                    </div>
+                    <div className="mt-6 rounded-xl border border-dashed border-accent/40 bg-accent/10 p-4 text-sm text-accent">
+                      <p className="font-semibold uppercase tracking-[0.3em] text-accent/80">Interaction</p>
+                      <p className="mt-2 text-accent/80">{item.interaction}</p>
+                    </div>
                   </motion.div>
-                )}
-              </AnimatePresence>
+                ))}
+              </div>
             </motion.div>
-          );
-        })}
+          </AnimatePresence>
+        </section>
+
+        <section className="rounded-3xl border border-border/60 bg-background-subtle/80 p-6 shadow-lg sm:p-8">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <h2 className="text-sm font-semibold uppercase tracking-[0.35em] text-muted">Codex orchestration</h2>
+              <p className="mt-3 max-w-3xl text-body-md text-muted">
+                Updates to the Codex ripple through the hero storyline, interactive demo, and plan board. The stack view mirrors that structure so the narrative stays synchronized.
+              </p>
+            </div>
+            <motion.span
+              className="inline-flex items-center gap-2 rounded-full border border-accent/40 bg-accent/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.4em] text-accent"
+              animate={{ opacity: [0.6, 1, 0.6] }}
+              transition={{ duration: 3, repeat: Infinity }}
+            >
+              <Sparkles className="h-4 w-4" /> Codex linked
+            </motion.span>
+          </div>
+        </section>
       </div>
-    </motion.div>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary
- centralize hero, demo, plan, and stack content in `src/data/codex.ts` so pages share a single source of truth
- build animated hero, scenario, and metric showcase components and wire them into the homepage and AIXUS demo experience
- refactor plan and stack pages to render codex data with inline editors, drag-and-drop, and layered navigation updates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e70ae50e4c8323aa68e708099d1ca7